### PR TITLE
make test work for rtems

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -42,7 +42,7 @@ PROD_vxWorks = vxTestHarness
 vxTestHarness_SRCS += $(testHarness_SRCS)
 TESTSPEC_vxWorks = vxTestHarness.$(MUNCH_SUFFIX); pvaClientAllTests
 
-#PROD_RTEMS += rtemsTestHarness
+PROD_RTEMS += rtemsTestHarness
 rtemsTestHarness_SRCS += rtemsTestHarness.c rtemsConfig.c
 rtemsTestHarness_SRCS += $(testHarness_SRCS)
 TESTSPEC_RTEMS = rtemsTestHarness.$(MUNCH_SUFFIX); pvaClientAllTests

--- a/test/qemuRunTest.sh
+++ b/test/qemuRunTest.sh
@@ -1,0 +1,1 @@
+qemu-system-i386 --kernel O.RTEMS-pc386/rtemsTestHarness -netdev user,id=mynet0 -device ne2k_isa,netdev=mynet0 -redir tcp:5075::5075 -redir udp:5076::5076 -m 1024 --no-reboot -curses

--- a/test/rtemsConfig.c
+++ b/test/rtemsConfig.c
@@ -1,0 +1,72 @@
+/*************************************************************************\
+* Copyright (c) 2002 The University of Saskatchewan
+* EPICS BASE Versions 3.13.7
+* and higher are distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution. 
+\*************************************************************************/
+/*
+ * RTEMS configuration for EPICS
+ *  Revision-Id: anj@aps.anl.gov-20101005192737-disfz3vs0f3fiixd
+ *      Author: W. Eric Norum
+ *              norume@aps.anl.gov
+ *              (630) 252-4793
+ */
+
+#include <rtems.h>
+
+/*
+ ***********************************************************************
+ *                         RTEMS CONFIGURATION                         *
+ ***********************************************************************
+ */
+#define CONFIGURE_RTEMS_INIT_TASKS_TABLE
+
+#if __RTEMS_MAJOR__>4 || (__RTEMS_MAJOR__==4 && __RTEMS_MINOR__>9) || (__RTEMS_MAJOR__==4 && __RTEMS_MINOR__==9 && __RTEMS_REVISION__==99)
+#  define CONFIGURE_UNIFIED_WORK_AREAS
+#else
+#  define CONFIGURE_EXECUTIVE_RAM_SIZE (2000*1024)
+#endif
+
+#define CONFIGURE_MAXIMUM_TASKS             rtems_resource_unlimited(30)
+#define CONFIGURE_MAXIMUM_SEMAPHORES        rtems_resource_unlimited(500)
+#define CONFIGURE_MAXIMUM_TIMERS            rtems_resource_unlimited(20)
+#define CONFIGURE_MAXIMUM_MESSAGE_QUEUES    rtems_resource_unlimited(5)
+#define CONFIGURE_MAXIMUM_USER_EXTENSIONS   1
+
+#define CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS 150
+#define CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM
+#define CONFIGURE_MAXIMUM_DRIVERS       8
+
+#define CONFIGURE_MICROSECONDS_PER_TICK 20000
+
+#define CONFIGURE_INIT_TASK_PRIORITY    80
+
+#define CONFIGURE_MALLOC_STATISTICS     1
+
+#define CONFIGURE_INIT
+#define CONFIGURE_INIT_TASK_INITIAL_MODES (RTEMS_PREEMPT | \
+                    RTEMS_NO_TIMESLICE | \
+                    RTEMS_NO_ASR | \
+                    RTEMS_INTERRUPT_LEVEL(0))
+#define CONFIGURE_INIT_TASK_ATTRIBUTES (RTEMS_FLOATING_POINT | RTEMS_LOCAL)
+#define CONFIGURE_INIT_TASK_STACK_SIZE  (16*1024)
+rtems_task Init (rtems_task_argument argument);
+
+#define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
+#define CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER
+
+#define CONFIGURE_FILESYSTEM_NFS
+#define CONFIGURE_FILESYSTEM_IMFS
+
+/*
+ * This should be made BSP dependent, not CPU dependent but I know of no
+ * appropriate conditionals to use.
+ * The new general time support makes including the RTC driver less important.
+ */
+#if !defined(mpc604) && !defined(__mc68040__) && !defined(__mcf5200__) && !defined(mpc7455) && !defined(__arm__)  /* don't have RTC code */
+#define CONFIGURE_APPLICATION_NEEDS_RTC_DRIVER
+#endif
+
+
+#include <bsp.h>
+#include <rtems/confdefs.h>

--- a/test/rtemsNetworking.h
+++ b/test/rtemsNetworking.h
@@ -1,0 +1,294 @@
+/*
+ * Network configuration -- QEMU NOT using DHCP
+ * 
+ ************************************************************
+ * EDIT THIS FILE TO REFLECT YOUR NETWORK CONFIGURATION     *
+ * BEFORE RUNNING ANY RTEMS PROGRAMS WHICH USE THE NETWORK! * 
+ ************************************************************
+ *
+ *  The dynamic probing is based upon the EPICS network
+ *  configuration file written by:
+ *      W. Eric Norum
+ *      eric.norum@usask.ca
+ *      (306) 966-5394
+ */
+
+#ifndef _RTEMS_NETWORKCONFIG_H_
+#define _RTEMS_NETWORKCONFIG_H_
+
+/* #define USE_LIBBSDPORT */
+
+#if defined(USE_LIBBSDPORT)
+  #include <bsp/libbsdport_api.h>
+  #define CONFIGURE_MAXIMUM_TIMERS 10
+#endif
+/*
+ * For TFTP test application
+ */
+#if (defined (RTEMS_USE_BOOTP))
+#define RTEMS_TFTP_TEST_HOST_NAME "BOOTP_HOST"
+#define RTEMS_TFTP_TEST_FILE_NAME "BOOTP_FILE"
+#else
+#define RTEMS_TFTP_TEST_HOST_NAME "XXX.YYY.ZZZ.XYZ"
+#define RTEMS_TFTP_TEST_FILE_NAME "tftptest"
+#endif
+
+/*
+ * For NFS test application
+ * 
+ * NFS mount and a directory to ls once mounted
+ */
+#define RTEMS_NFS_SERVER      "192.168.1.210"
+#define RTEMS_NFS_SERVER_PATH "/home"
+#define RTEMS_NFS_LS_PATH     "/mnt/nfstest"
+
+
+
+/*
+ * This file can be copied to an application source directory
+ * and modified to override the values shown below.
+ *
+ * The following CPP symbols may be passed from the Makefile:
+ *
+ *   symbol                   default       description
+ *
+ *   NETWORK_TASK_PRIORITY    150           can be read by app from public
+ *                                          var 'gesysNetworkTaskPriority'
+ *   FIXED_IP_ADDR            <undefined>   hardcoded IP address (e.g.,
+ *                                          "192.168.0.10"); disables BOOTP;
+ *                                          must also define FIXED_NETMASK
+ *   FIXED_NETMASK            <undefined>   IP netmask string
+ *                                          (e.g. "255.255.255.0")
+ *   MULTI_NETDRIVER          <undefined>   ugly hack; if defined try to probe
+ *                                          a variety of PCI and ISA drivers
+ *                                          (i386 ONLY) use is discouraged!
+ *   NIC_NAME                 <undefined>   Ethernet driver name (e.g. "pcn1");
+ *                                          must also define NIC_ATTACH
+ *   NIC_ATTACH               <undefined>   Ethernet driver attach function
+ *                                          (e.g., rtems_fxp_attach).
+ *                                          If these are undefined then
+ *                                            a) MULTI_NETDRIVER is used
+ *                                               (if defined)
+ *                                            b) RTEMS_BSP_NETWORK_DRIVER_NAME/
+ *                                               RTEMS_BSP_NETWORK_DRIVER_ATTACH
+ *                                               are tried
+ *   MEMORY_CUSTOM            <undefined>   Allocate the defined amount of
+ *                                          memory for mbufs and mbuf clusters,
+ *                                          respectively. Define to a comma ','
+ *                                          separated pair of two numerical
+ *                                          values, e.g: 100*1024,200*1024
+ *   MEMORY_SCARCE            <undefined>   Allocate few memory for mbufs
+ *                                          (hint for how much memory the
+ *                                          board has)
+ *   MEMORY_HUGE              <undefined>   Allocate a lot of memory for mbufs
+ *                                          (hint for how much memory the
+ *                                          board has)
+ *                                          If none of MEMORY_CUSTOM/
+ *                                          MEMORY_SCARCE/MEMORY_HUGE are
+ *                                          defined then a medium amount of
+ *                                          memory is allocated for mbufs.
+ */
+
+#include <rtems/bspIo.h>
+#include <bsp.h>
+#include <rtems/rtems_bsdnet.h>
+
+#if 0
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#else
+#include "verscheck.h"
+#endif
+#endif
+
+//#define MULTI_NETDRIVER
+//#define RTEMS_BSP_NETWORK_DRIVER_NAME 1
+
+#define FIXED_IP_ADDR "192.168.1.249"
+#define FIXED_NETMASK "255.255.255.0"
+
+#ifndef NETWORK_TASK_PRIORITY
+#define NETWORK_TASK_PRIORITY   150  /* within EPICS' range */
+#endif
+
+/* make publicly available for startup scripts... */
+const int gesysNetworkTaskPriority = NETWORK_TASK_PRIORITY;
+
+#ifdef  FIXED_IP_ADDR
+#define RTEMS_DO_BOOTP 0
+#else
+#define RTEMS_DO_BOOTP rtems_bsdnet_do_bootp
+#define FIXED_IP_ADDR  0
+#undef  FIXED_NETMASK
+#define FIXED_NETMASK  0
+#endif
+
+#if !defined(NIC_NAME)
+
+#ifdef MULTI_NETDRIVER
+
+#if 0
+  #if RTEMS_VERSION_ATLEAST(4,6,99)
+  #define pcib_init pci_initialize
+  #endif
+#endif
+
+extern int rtems_3c509_driver_attach (struct rtems_bsdnet_ifconfig *, int);
+extern int rtems_fxp_attach (struct rtems_bsdnet_ifconfig *, int);
+extern int rtems_elnk_driver_attach (struct rtems_bsdnet_ifconfig *, int);
+extern int rtems_dec21140_driver_attach (struct rtems_bsdnet_ifconfig *, int);
+
+/* these don't probe and will be used even if there's no device :-( */
+extern int rtems_ne_driver_attach (struct rtems_bsdnet_ifconfig *, int);
+extern int rtems_wd_driver_attach (struct rtems_bsdnet_ifconfig *, int);
+
+static struct rtems_bsdnet_ifconfig isa_netdriver_config[] = {
+  {
+  	"ep0", rtems_3c509_driver_attach, isa_netdriver_config + 1,
+  },
+  {
+  	"ne1", rtems_ne_driver_attach, 0, irno: 9 /* qemu cannot configure irq-no :-(; has it hardwired to 9 */
+  },
+};
+
+static struct rtems_bsdnet_ifconfig pci_netdriver_config[]={
+  {
+  "dc1", rtems_dec21140_driver_attach, pci_netdriver_config+1,
+  },
+  #if !defined(USE_LIBBSDPORT)
+    {
+    "fxp1", rtems_fxp_attach, pci_netdriver_config+2,
+    },
+  #else
+    {
+      "", libbsdport_netdriver_attach, pci_netdriver_config+2,
+    },
+  #endif
+  {
+  "elnk1", rtems_elnk_driver_attach, isa_netdriver_config,
+  },
+};
+
+static int pci_check(struct rtems_bsdnet_ifconfig *ocfg, int attaching)
+{
+struct rtems_bsdnet_ifconfig *cfg;
+int if_index_pre;
+extern int if_index;
+  if ( attaching ) {
+  	cfg = pci_initialize() ?
+                      isa_netdriver_config : pci_netdriver_config;
+  }
+  while ( cfg ) {
+  	printk("Probing '%s'", cfg->name);
+  	/* unfortunately, the return value is unreliable - some drivers report
+  	 * success even if they fail.
+  	 * Check if they chained an interface (ifnet) structure instead
+  	 */
+  	if_index_pre = if_index;
+  	cfg->attach(cfg, attaching);
+  	if ( if_index > if_index_pre ) {
+  		/* assume success */
+  		printk(" .. seemed to work\n");
+  		ocfg->name   = cfg->name;
+  		ocfg->attach = cfg->attach;
+  		return 0;
+  	}
+  	printk(" .. failed\n");
+  	cfg = cfg->next;
+  }
+  return -1;
+}
+
+
+#define NIC_NAME   "dummy"
+#define NIC_ATTACH pci_check
+
+#else
+
+#if defined(RTEMS_BSP_NETWORK_DRIVER_NAME)  /* Use NIC provided by BSP */
+
+/* force ne2k_isa on i386 for qemu */
+#if defined(__i386__)
+# define NIC_NAME  BSP_NE2000_NETWORK_DRIVER_NAME
+# define NIC_ATTACH BSP_NE2000_NETWORK_DRIVER_ATTACH
+
+#else
+
+# define NIC_NAME  RTEMS_BSP_NETWORK_DRIVER_NAME
+# define NIC_ATTACH RTEMS_BSP_NETWORK_DRIVER_ATTACH
+#endif
+
+#endif
+
+#endif /* ifdef MULTI_NETDRIVER */
+#endif
+
+
+#ifdef NIC_NAME
+
+extern int NIC_ATTACH();
+
+#if RTEMS_BSP_NETWORK_DRIVER_ATTACH == BSP_NE2000_NETWORK_DRIVER_ATTACH
+static char ethernet_address[6] = { 0x00, 0xab, 0xcd, 0xef, 0x12, 0x34 };
+#endif
+
+static struct rtems_bsdnet_ifconfig netdriver_config[1] = {{
+  NIC_NAME,  /* name */
+  (int (*)(struct rtems_bsdnet_ifconfig*,int))NIC_ATTACH,  /* attach function */
+  0,  		/* link to next interface */
+  FIXED_IP_ADDR,
+  FIXED_NETMASK
+#if RTEMS_BSP_NETWORK_DRIVER_ATTACH == BSP_NE2000_NETWORK_DRIVER_ATTACH
+  ,
+  ethernet_address,
+  irno:9,
+  port:0xc100
+#endif
+}};
+#else
+#warning "NO KNOWN NETWORK DRIVER FOR THIS BSP -- YOU MAY HAVE TO EDIT networkconfig.h"
+#endif
+
+struct rtems_bsdnet_config rtems_bsdnet_config = {
+#ifdef NIC_NAME
+    netdriver_config,         /* link to next interface */
+    RTEMS_DO_BOOTP,           /* Use BOOTP to get network configuration */
+#else
+    0,
+    0,
+#endif
+    NETWORK_TASK_PRIORITY,    /* Network task priority */
+#if   defined(MEMORY_CUSTOM)
+    MEMORY_CUSTOM,
+#elif defined(MEMORY_SCARCE)
+    100*1024,                 /* MBUF space */
+    200*1024,                 /* MBUF cluster space */
+#elif defined(MEMORY_HUGE)
+    2*1024*1024,              /* MBUF space */
+    5*1024*1024,              /* MBUF cluster space */
+#else
+    180*1024,                 /* MBUF space */
+    350*1024,                 /* MBUF cluster space */
+#endif
+#if (!defined (RTEMS_USE_BOOTP)) && defined(ON_RTEMS_LAB_WINSYSTEMS)
+    "rtems",                /* Host name */
+    "nodomain.com",         /* Domain name */
+    "192.168.1.14",         /* Gateway */
+    "192.168.1.1",          /* Log host */
+    {"89.212.75.6"  },      /* Name server(s) */
+    {"192.168.1.1"  },      /* NTP server(s) */
+#else
+    NULL,                   /* Host name */
+    NULL,                   /* Domain name */
+    NULL,                   /* Gateway */
+    NULL,                   /* Log host */
+    { NULL },               /* Name server(s) */
+    { NULL },               /* NTP server(s) */
+#endif /* !RTEMS_USE_BOOTP */
+    0,                      /* efficiency */
+    0,                      /* udp TX buffer */
+    0,                      /* udp RX buffer */
+    0,                      /* tcp TX buffer */
+    0,                      /* tcp RX buffer */
+};
+#endif /* _RTEMS_NETWORKCONFIG_H_ */

--- a/test/rtemsTestHarness.c
+++ b/test/rtemsTestHarness.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <rtems/rtems_bsdnet.h>
+#include <rtems/error.h>
+
+#include "rtemsNetworking.h"
+
+#include <epicsExit.h>
+#include <osdTime.h>
+
+extern void pvDatabaseAllTests(void);
+
+rtems_task
+Init (rtems_task_argument ignored)
+{
+  rtems_bsdnet_initialize_network ();
+  //rtems_bsdnet_show_if_stats ();
+
+  rtems_time_of_day timeOfDay;
+  if (rtems_clock_get(RTEMS_CLOCK_GET_TOD,&timeOfDay) != RTEMS_SUCCESSFUL) {
+    timeOfDay.year = 2014;
+    timeOfDay.month = 1;
+    timeOfDay.day = 1;
+    timeOfDay.hour = 0;
+    timeOfDay.minute = 0;
+    timeOfDay.second = 0;
+    timeOfDay.ticks = 0;
+
+    rtems_status_code ret = rtems_clock_set(&timeOfDay);
+    if (ret != RTEMS_SUCCESSFUL) {
+      printf("**** Can't set time %s\n", rtems_status_text(ret));
+    }
+  }
+  osdTimeRegister();
+  
+  pvaClientAllTests();
+  epicsExit(0);
+}


### PR DESCRIPTION
The following files have been copied from pvDatabaseCPP/test to  exampleCPP/test:
qemuRunTest.sh rtemsConfig.c rtemsNetworking.h rtemsTestHarness.c

The only files that was changed is rtemsTestHarness.c
mrk> diff rtemsTestHarness.c /home/epicsv4/master/pvDatabaseCPP/test
36c36
<   pvaClientAllTests();
---
>   pvDatabaseAllTests();
mrk> 

I also changed test/Makefile
-#PROD_RTEMS += rtemsTestHarness
+PROD_RTEMS += rtemsTestHarness
 
Lets see if this is all that is required.