### PR TITLE
Fix Windows build issues

### DIFF
--- a/ChannelArchiverService/configure/CONFIG_SITE
+++ b/ChannelArchiverService/configure/CONFIG_SITE
@@ -19,7 +19,7 @@
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/arrayPerformance/configure/CONFIG_SITE
+++ b/arrayPerformance/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/arrayPerformance/src/Makefile
+++ b/arrayPerformance/src/Makefile
@@ -13,7 +13,7 @@ LIBSRCS += arrayPerformance.cpp
 LIBSRCS += longArrayGet.cpp
 LIBSRCS += longArrayMonitor.cpp
 LIBSRCS += longArrayPut.cpp
-arrayPerform_LIBS += pvDatabase pvAccess pvData Com
+arrayPerform_LIBS += pvDatabase pvaClient pvAccess pvData Com
 
 PROD_HOST += arrayPerformanceMain
 arrayPerformanceMain_SRCS += arrayPerformanceMain.cpp

--- a/database/configure/CONFIG_SITE
+++ b/database/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/exampleClient/configure/CONFIG_SITE
+++ b/exampleClient/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/exampleLink/configure/CONFIG_SITE
+++ b/exampleLink/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/exampleLink/src/Makefile
+++ b/exampleLink/src/Makefile
@@ -11,7 +11,7 @@ DBD += exampleLinkRegister.dbd
 LIBRARY = exampleLink
 LIBSRCS += exampleLinkRecord.cpp
 LIBSRCS += exampleLinkRegister.cpp
-exampleLink_LIBS += pvDatabase pvAccess nt pvData ca Com
+exampleLink_LIBS += pvDatabase pvaClient pvAccess nt pvData ca Com
 
 PROD_HOST += exampleLinkMain
 exampleLinkMain_SRCS += exampleLinkMain.cpp

--- a/helloPutGet/configure/CONFIG_SITE
+++ b/helloPutGet/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/helloRPC/configure/CONFIG_SITE
+++ b/helloRPC/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/powerSupply/configure/CONFIG_SITE
+++ b/powerSupply/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS =
+#CROSS_COMPILER_TARGET_ARCHS =
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.

--- a/test/pvaClientAllTests.c
+++ b/test/pvaClientAllTests.c
@@ -20,8 +20,6 @@ int pvaClientTestPutData(void);
 int pvaClientTestMonitorData(void);
 int pvaClientTestPutGetMonitor(void);
 int pvaClientTestPutGet(void);
-int pvaClientTestMultiDouble(void);
-int pvaClientTestNTMultiChannel(void);
 
 void pvaClientAllTests(void)
 {
@@ -35,8 +33,6 @@ void pvaClientAllTests(void)
     runTest(pvaClientTestMonitorData);
     runTest(pvaClientTestPutGetMonitor);
     runTest(pvaClientTestPutGet);
-    runTest(pvaClientTestMultiDouble);
-    runTest(pvaClientTestNTMultiChannel);
 
     epicsExit(0);
 }

--- a/test/pvaClientAllTests.c
+++ b/test/pvaClientAllTests.c
@@ -11,6 +11,7 @@
  */
 
 #include <stdio.h>
+#include <epicsExit.h>
 #include <epicsThread.h>
 #include <epicsUnitTest.h>
 


### PR DESCRIPTION
The main fixes for Windows are the second and fourth commits; your Makefiles were not linking the pvaClient library into the libraries being created, which is not needed on Linux but is on Windows. The other commits were necessary for my build to complete and hence find the problem (I can cross-compile for the windows-x64-mingw target on my Linux system now).

- Andrew
