### PR TITLE
The most important change is to use only required providers.

### DIFF
--- a/KNOWNPROBLEMS.md
+++ b/KNOWNPROBLEMS.md
@@ -1,0 +1,41 @@
+# Known Problems
+
+## monitors
+
+When a monitor is issued to a channel that is served by dbPv (pvaSrv),
+Each monitors shows that all requested fields have changed.
+
+## helloRPC
+
+helloService does not terminate.
+
+## exampleLink
+
+Run as:
+
+    mrk> pwd
+    /home/epicsv4/master/exampleCPP/exampleLink/iocBoot/exampleLink
+    mrk> ../../bin/linux-x86_64/exampleLink st.ca
+
+When exit is requested a Segmentation fault occurs.
+
+Note that this does not happen when run as:
+
+    mrk> pwd
+    /home/epicsv4/master/exampleCPP/exampleLink
+    mrk> bin/linux-x86_64/exampleLinkMain  ca exampleLink doubleArray false
+
+## powerSupply
+
+The powerSupplyClient ends with setting voltage to 0.
+This causes the PVRecord to throw an exception, which pvAccess passes back to the client.
+All appears OK except that if another client has a monitor on the PVRecord,
+that client no longer gets an monitor updates.
+
+## memory leaks
+
+When any of the examples terminate valgrind shows memory leaks.
+Clients not so bad but servers not so good.
+
+
+

--- a/arrayPerformance/src/arrayPerformanceMain.cpp
+++ b/arrayPerformance/src/arrayPerformanceMain.cpp
@@ -77,7 +77,7 @@ int main(int argc,char *argv[])
         
         ChannelProviderLocalPtr channelProvider = getChannelProviderLocal();
         ServerContext::shared_pointer ctx = 
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+        startPVAServer("local",0,true,true);
         ArrayPerformancePtr arrayPerformance =ArrayPerformance::create(recordName,size,delay);
         master->addRecord(arrayPerformance);
         arrayPerformance->startThread();

--- a/arrayPerformance/src/longArrayGet.cpp
+++ b/arrayPerformance/src/longArrayGet.cpp
@@ -47,7 +47,7 @@ void LongArrayGet::stop()
 
 void LongArrayGet::run()
 {
-    PvaClientPtr pva(PvaClient::create());
+    PvaClientPtr pva(PvaClient::get("pva"));
     PvaClientChannelPtr pvaChannel(pva->createChannel(channelName,providerName));
     PvaClientGetPtr pvaGet(pvaChannel->createGet("value,alarm,timeStamp"));
     TimeStamp timeStamp;

--- a/arrayPerformance/src/longArrayMonitor.cpp
+++ b/arrayPerformance/src/longArrayMonitor.cpp
@@ -48,7 +48,7 @@ void LongArrayMonitor::stop()
 
 void LongArrayMonitor::run()
 {
-    PvaClientPtr pva(PvaClient::create());
+    PvaClientPtr pva(PvaClient::get("pva"));
     string  request("record[queueSize=");
     char buff[20];
     sprintf(buff,"%d",queueSize);

--- a/arrayPerformance/src/longArrayPut.cpp
+++ b/arrayPerformance/src/longArrayPut.cpp
@@ -50,7 +50,7 @@ void LongArrayPut::stop()
 
 void LongArrayPut::run()
 {
-    PvaClientPtr pva(PvaClient::create());
+    PvaClientPtr pva(PvaClient::get("pva"));
     PvaClientChannelPtr pvaChannel(pva->createChannel(channelName,providerName));
     PvaClientPutPtr pvaPut(pvaChannel->createPut("value"));
     TimeStamp timeStamp;

--- a/database/src/exampleDatabase.cpp
+++ b/database/src/exampleDatabase.cpp
@@ -219,7 +219,8 @@ void ExampleDatabase::create()
     recordName = "PVRhelloPutGet";
     result = master->addRecord(ExampleHelloRecord::create(recordName));
     if(!result) cout<< "record " << recordName << " not added" << endl;
-    RPCServer::shared_pointer server(new RPCServer());
-    server->registerService("helloRPC",ExampleHelloRPC::create());
+    recordName = "helloRPC";
+    result = master->addRecord(ExampleHelloRPC::create(recordName));
+    if(!result) cout<< "record " << recordName << " not added" << endl;
 }
 

--- a/database/src/exampleDatabaseMain.cpp
+++ b/database/src/exampleDatabaseMain.cpp
@@ -35,7 +35,7 @@ int main(int argc,char *argv[])
     ChannelProviderLocalPtr channelProvider = getChannelProviderLocal();
     ExampleDatabase::create();
     ServerContext::shared_pointer ctx =
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+        startPVAServer("local",0,true,true);
     
     master.reset();
     cout << "exampleDatabase\n";

--- a/exampleClient/src/examplePvaClientGet.cpp
+++ b/exampleClient/src/examplePvaClientGet.cpp
@@ -69,7 +69,7 @@ static void exampleDoubleArray(PvaClientPtr const &pva,string const & channelNam
 int main(int argc,char *argv[])
 {
     cout << "_____examplePvaClientGet starting_______\n";
-    PvaClientPtr pva= PvaClient::create();
+    PvaClientPtr pva= PvaClient::get("pva ca");
     try {
         exampleDouble(pva,"PVRdouble","pva");
         exampleDoubleArray(pva,"PVRdoubleArray","pva");

--- a/exampleClient/src/examplePvaClientMonitor.cpp
+++ b/exampleClient/src/examplePvaClientMonitor.cpp
@@ -52,7 +52,7 @@ static void exampleMonitor(PvaClientPtr const &pva,string const & recordName,str
 int main(int argc,char *argv[])
 {
     cout << "_____examplePvaClientMonitor starting_______\n";
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva ca");
     try {
         exampleMonitor(pva,"PVRdouble","pva");
         PvaClientChannelPtr pvaChannel = pva->createChannel("DBRdouble00","ca");

--- a/exampleClient/src/examplePvaClientMultiDouble.cpp
+++ b/exampleClient/src/examplePvaClientMultiDouble.cpp
@@ -59,7 +59,7 @@ static void example(
 int main(int argc,char *argv[])
 {
     cout << "_____examplePvaClientMultiDouble starting_______\n";
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva ca");
     try {
         size_t num = 5;
         shared_vector<string> channelNames(num);

--- a/exampleClient/src/examplePvaClientNTMulti.cpp
+++ b/exampleClient/src/examplePvaClientNTMulti.cpp
@@ -128,7 +128,7 @@ static void example(
 int main(int argc,char *argv[])
 {
     cout << "_____examplePvaClientNTMulti starting_______\n";
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva ca");
     size_t num = 4;
     shared_vector<string> channelNames(num);
     channelNames[0] = "PVRdouble";

--- a/exampleClient/src/examplePvaClientProcess.cpp
+++ b/exampleClient/src/examplePvaClientProcess.cpp
@@ -33,7 +33,7 @@ static void exampleProcess(PvaClientPtr const &pva)
 
 int main(int argc,char *argv[])
 {
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva");
     try {
         exampleProcess(pva);
     } catch (std::runtime_error e) {

--- a/exampleClient/src/examplePvaClientPut.cpp
+++ b/exampleClient/src/examplePvaClientPut.cpp
@@ -88,7 +88,7 @@ static void examplePVFieldPut(PvaClientPtr const &pva,string const & channelName
 int main(int argc,char *argv[])
 {
     cout << "_____examplePvaClientPut starting_______\n";
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva ca");
     try {
         exampleDouble(pva,"PVRdouble","pva");
         exampleDoubleArray(pva,"PVRdoubleArray","pva");

--- a/exampleClient/src/helloWorldPutGet.cpp
+++ b/exampleClient/src/helloWorldPutGet.cpp
@@ -37,7 +37,7 @@ static void example(PvaClientPtr const &pva)
 
 int main(int argc,char *argv[])
 {
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva");
     try {
         example(pva);
     } catch (std::runtime_error e) {

--- a/exampleLink/iocBoot/exampleLink/st.ca
+++ b/exampleLink/iocBoot/exampleLink/st.ca
@@ -12,4 +12,4 @@ dbLoadRecords("db/ai.db","name=exampleLinkAI");
 cd ${TOP}/iocBoot/${IOC}
 iocInit()
 startPVAServer local
-exampleLinkCreateRecord local
+exampleLinkCreateRecord ca exampleLink doubleArray false

--- a/exampleLink/iocBoot/exampleLink/st.cmd
+++ b/exampleLink/iocBoot/exampleLink/st.cmd
@@ -11,6 +11,5 @@ dbLoadRecords("db/ai.db","name=exampleLinkAI");
 
 cd ${TOP}/iocBoot/${IOC}
 iocInit()
-startPVAClient
-startPVAServer
-exampleLinkCreateRecord exampleLink pva doubleArray
+startPVAServer local
+exampleLinkCreateRecord

--- a/exampleLink/iocBoot/exampleLink/st.external
+++ b/exampleLink/iocBoot/exampleLink/st.external
@@ -12,4 +12,4 @@ dbLoadRecords("db/ai.db","name=exampleLinkAI");
 cd ${TOP}/iocBoot/${IOC}
 iocInit()
 startPVAServer local
-exampleLinkCreateRecord local
+exampleLinkCreateRecord pva exampleLink doubleArray false

--- a/exampleLink/src/doubleArrayMain.cpp
+++ b/exampleLink/src/doubleArrayMain.cpp
@@ -51,7 +51,7 @@ int main(int argc,char *argv[])
             createPVStructure();
         master->addRecord(PVRecord::create(doubleArrayRecordName,pvStructure));
         ServerContext::shared_pointer ctx =
-            startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+            startPVAServer("local",0,true,true);
         string str;
         while(true) {
             cout << "Type exit to stop: \n";

--- a/exampleLink/src/exampleLinkClient.cpp
+++ b/exampleLink/src/exampleLinkClient.cpp
@@ -29,7 +29,9 @@ int main(int argc,char *argv[])
     }
     if(argc>1) provider = argv[1];
     cout << "_____exampleLinkClient starting_______\n";
-    PvaClientPtr pva = PvaClient::create();
+    string providers("pva");
+    if(provider=="ca") providers = "pva ca";
+    PvaClientPtr pva = PvaClient::get(providers);
     try {
         PvaClientPutPtr put = pva->channel("doubleArray",provider,5.0)->put();
         PvaClientPutDataPtr putData = put->getData();

--- a/exampleLink/src/exampleLinkMain.cpp
+++ b/exampleLink/src/exampleLinkMain.cpp
@@ -54,9 +54,10 @@ int main(int argc,char *argv[])
     try {
         PVDatabasePtr master = PVDatabase::getMaster();
         ChannelProviderLocalPtr channelProvider = getChannelProviderLocal();
+        PvaClientPtr pva= PvaClient::get(provider);
         ServerContext::shared_pointer ctx =
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
-        PvaClientPtr pva= PvaClient::create();
+        startPVAServer("local",0,true,true);
+        
         if(generateLinkedRecord) {
             NTScalarArrayBuilderPtr ntScalarArrayBuilder = NTScalarArray::createBuilder();
             PVStructurePtr pvStructure = ntScalarArrayBuilder->
@@ -64,12 +65,12 @@ int main(int argc,char *argv[])
                 addAlarm()->
                 addTimeStamp()->
                 createPVStructure();
-            master->addRecord(PVRecord::create(linkedRecordName,pvStructure));
+            PVRecordPtr pvRecord(PVRecord::create(linkedRecordName,pvStructure));
+            master->addRecord(pvRecord);
         }
         ExampleLinkRecordPtr pvRecord(
             ExampleLinkRecord::create(
                  pva,exampleLinkRecordName,provider,linkedRecordName));
-
         master->addRecord(pvRecord);
         cout << "exampleLink\n";
         string str;

--- a/exampleLink/src/exampleLinkRecord.cpp
+++ b/exampleLink/src/exampleLinkRecord.cpp
@@ -59,9 +59,8 @@ bool ExampleLinkRecord::init(PvaClientPtr const & pva,string const & channelName
         return false;
     }
     PvaClientChannelPtr pvaClientChannel = pva->channel(channelName,providerName,0.0);
-   PvaClientMonitorRequester::shared_pointer  monitorRequester =
-        dynamic_pointer_cast<PvaClientMonitorRequester>(getPtrSelf());
-    pvaClientChannel->monitor("value",monitorRequester);
+    monitorRequester = dynamic_pointer_cast<PvaClientMonitorRequester>(getPtrSelf());
+    pvaClientMonitor = pvaClientChannel->monitor("value",monitorRequester);
     return true;
 }
 

--- a/exampleLink/src/pv/exampleLinkRecord.h
+++ b/exampleLink/src/pv/exampleLinkRecord.h
@@ -63,6 +63,8 @@ private:
         std::string const & providerName
         );
     epics::pvData::PVDoubleArrayPtr pvValue;
+    epics::pvaClient::PvaClientMonitorRequester::shared_pointer  monitorRequester;
+    epics::pvaClient::PvaClientMonitorPtr pvaClientMonitor;
 };
 
 }}}

--- a/helloPutGet/src/helloPutGetClient.cpp
+++ b/helloPutGet/src/helloPutGetClient.cpp
@@ -20,7 +20,7 @@ using namespace epics::pvaClient;
 
 int main(int argc,char *argv[])
 {
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva");
     try {
         PvaClientChannelPtr channel = pva->channel("helloPutGet");
         PvaClientPutGetPtr putGet = channel->createPutGet();

--- a/helloPutGet/src/helloPutGetMain.cpp
+++ b/helloPutGet/src/helloPutGetMain.cpp
@@ -34,7 +34,7 @@ int main(int argc,char *argv[])
     master->addRecord(pvRecord);
 
     ServerContext::shared_pointer ctx =
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+        startPVAServer("local",0,true,true);
     string str;
     while(true) {
         cout << "Type exit to stop: \n";

--- a/helloPutGet/src/helloPutGetRecord.cpp
+++ b/helloPutGet/src/helloPutGetRecord.cpp
@@ -27,12 +27,12 @@ HelloPutGetRecordPtr HelloPutGetRecord::create(
     FieldCreatePtr fieldCreate = getFieldCreate();
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
     StructureConstPtr  topStructure = fieldCreate->createFieldBuilder()->
+        add("timeStamp",standardField->timeStamp()) ->
         addNestedStructure("argument")->
             add("value",pvString)->
             endNested()->
         addNestedStructure("result") ->
-            add("value",pvString) ->
-            add("timeStamp",standardField->timeStamp()) ->
+            add("value",pvString) ->    
             endNested()->
         createStructure();
     PVStructurePtr pvStructure = pvDataCreate->createPVStructure(topStructure);

--- a/powerSupply/src/powerSupplyClient.cpp
+++ b/powerSupply/src/powerSupplyClient.cpp
@@ -20,7 +20,7 @@ using namespace epics::pvaClient;
 
 int main(int argc,char *argv[])
 {
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva");
     try {
         PvaClientChannelPtr pvaChannel = pva->channel("powerSupply"); 
         PvaClientPutGetPtr putGet(pvaChannel->createPutGet(

--- a/powerSupply/src/powerSupplyMain.cpp
+++ b/powerSupply/src/powerSupplyMain.cpp
@@ -36,7 +36,7 @@ int main(int argc,char *argv[])
     master->addRecord(pvRecord);
 
     ServerContext::shared_pointer ctx =
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+        startPVAServer("local",0,true,true);
     
     string str;
     while(true) {

--- a/powerSupply/src/powerSupplyMonitor.cpp
+++ b/powerSupply/src/powerSupplyMonitor.cpp
@@ -23,7 +23,7 @@ using namespace epics::pvaClient;
 
 int main(int argc,char *argv[])
 {
-    PvaClientPtr pva = PvaClient::create();
+    PvaClientPtr pva = PvaClient::get("pva");
     try {
         PvaClientMonitorPtr monitor = pva->channel("powerSupply")->monitor("");
         while(true) {

--- a/pvDatabaseRPC/src/exampleRPCMain.cpp
+++ b/pvDatabaseRPC/src/exampleRPCMain.cpp
@@ -33,7 +33,7 @@ int main(int argc,char *argv[])
     master->addRecord(pvRecord);
 
     ServerContext::shared_pointer ctx =
-        startPVAServer(PVACCESS_ALL_PROVIDERS,0,true,true);
+        startPVAServer("local",0,true,true);
     
     string str;
     while(true) {

--- a/test/pvaClientTest.cpp
+++ b/test/pvaClientTest.cpp
@@ -98,7 +98,7 @@ MAIN(pvaClientTest)
     testPlan(7);
     testDiag("=== pvaClientTest ===");
 
-    PvaClientPtr pvaClient = PvaClient::create();
+    PvaClientPtr pvaClient = PvaClient::get("pva ca");
     example(pvaClient);
 
     testDone();

--- a/test/pvaClientTestGetData.cpp
+++ b/test/pvaClientTestGetData.cpp
@@ -188,7 +188,7 @@ static void testDoubleArray()
 
 MAIN(pvaClientTestGetData)
 {
-    pvaClient = PvaClient::create();
+    pvaClient = PvaClient::get("pva");
     fieldCreate = getFieldCreate();
     standardField = getStandardField();
     pvDataCreate = getPVDataCreate();

--- a/test/pvaClientTestMonitorData.cpp
+++ b/test/pvaClientTestMonitorData.cpp
@@ -185,7 +185,7 @@ static void testDoubleArray()
 
 MAIN(pvaClientTestMonitorData)
 {
-    pvaClient = PvaClient::create();
+    pvaClient = PvaClient::get("pva");
     fieldCreate = getFieldCreate();
     standardField = getStandardField();
     pvDataCreate = getPVDataCreate();

--- a/test/pvaClientTestPutData.cpp
+++ b/test/pvaClientTestPutData.cpp
@@ -284,7 +284,7 @@ static void testDoubleArray()
 
 MAIN(pvaClientTestPutData)
 {
-    pvaClient = PvaClient::create();
+    pvaClient = PvaClient::get("pva");
     fieldCreate = getFieldCreate();
     standardField = getStandardField();
     pvDataCreate = getPVDataCreate();

--- a/test/pvaClientTestPutGet.cpp
+++ b/test/pvaClientTestPutGet.cpp
@@ -90,7 +90,7 @@ MAIN(pvaClientTestPutGet)
     testPlan(3);
     testDiag("=== pvaClientTestPutGet ===");
 
-    PvaClientPtr pvaClient = PvaClient::create();
+    PvaClientPtr pvaClient = PvaClient::get("pva");
     example(pvaClient);
 
     testDone();

--- a/test/pvaClientTestPutGetMonitor.cpp
+++ b/test/pvaClientTestPutGetMonitor.cpp
@@ -126,7 +126,7 @@ MAIN(pvaClientTestPutGetMonitor)
     testPlan(19);
     testDiag("=== pvaClientTestPutGetMonitor ===");
 
-    PvaClientPtr pvaClient = PvaClient::create();
+    PvaClientPtr pvaClient = PvaClient::get("pva");
     exampleDouble(pvaClient);
 
     testDone();


### PR DESCRIPTION
In addition exampleLink, both as main and as part of a V3 IOC,
Now has tests for providers local, pva, and ca.
It also allows the linked channel to be in the same IOC or in another
IOC.

A lot of time was spent making the examples consistant between
exampleCPP and exampleJava.