### PR TITLE
pvDatabaseRPC: Replace "move" by multiple operations

### DIFF
--- a/pvDatabaseRPC/README.md
+++ b/pvDatabaseRPC/README.md
@@ -1,6 +1,18 @@
 # pvDatabaseRPC
 
-An example of a pvDatabase PVRecord which also supports RPC services.
+A pvAccess server that has a PVRecord that supports Channel RPC as well as
+the usual operations: Channel Get, Put and Monitor and get introspection
+data.
+
+It illustrates synchronous and asynchronous RPC services, selecting services
+based on the supplied pvRequest and using EPICS V4 to talk to an existing
+object which has no knowledge of EPICS and call its methods, so creating 
+distributed objects.
+
+It represents a device which has a 2D position setpoint and readback as well
+as a state. The device can be controlled through a client using RPC commands
+to move through a sequence of points as well as conventionally by putting to
+the setpoint.
 
 ## Building
 
@@ -19,4 +31,68 @@ In **configure/RELEASE.local** it may only be necessary to change the definition
 of **EPICS4_DIR** and **EPICS_BASE**.
 
 
+## To start the exampleRPC as a standalone main
+
+    ./bin/$EPICS_HOST_ARCH/exampleRPCMain
+
+# To set a position using pvput (with pvput in your path)
+
+    pvput -r positionSP.value mydevice 1 2
+
+
+## To run control
+
+In the exampleJava/pvDatabaseRPC directory
+
+On Linux
+
+    ./bin/$EPICS_HOST_ARCH/control <command> [<args>]
+
+E.g.
+    ./bin/$EPICS_HOST_ARCH/control help
+    ./bin/$EPICS_HOST_ARCH/control configure 1 2 10 20
+    ./bin/$EPICS_HOST_ARCH/control run
+    ./bin/$EPICS_HOST_ARCH/control pause
+    ./bin/$EPICS_HOST_ARCH/control resume
+    ./bin/$EPICS_HOST_ARCH/control rewind 5
+    ./bin/$EPICS_HOST_ARCH/control stop
+    ./bin/$EPICS_HOST_ARCH/control scan
+    ./bin/$EPICS_HOST_ARCH/control abort
+
+
+## Device and client operation
+
+The device has 4 states: IDLE, READY, RUNNING and PAUSED.
+
+In the IDLE state the device can be controlled in a conventional way by
+writing to the positionSP (setpoint) field. The device's positionRB field
+(readback) will move to the setpoint. In other states such writes
+are ignored. Writes to other fields are always ignored.
+
+From IDLE the command "configure" sets the sequence of points through which
+the device will move and changes state to READY.
+
+From READY the command "run" will start the device moving through the sequence
+of points and set the state to RUNNING. The command "scan" does the same but
+blocks until completion. On successful completion in each case the state will
+return to READY. Any motion will stop. 
+
+In the RUNNING state "pause" pauses the scan and changes the state to PAUSED.
+When PAUSED, "resume" resumes the scan.
+
+When RUNNING or PAUSED "rewind" (which takes an integer argument "n") rewinds
+n steps (or to the beginning if n is sufficiently large). If PAUSED the device
+will move to the requested rewind position when it resumes.
+
+In any state except IDLE "stop" stops a scan and the state goes to READY.
+A "scan" operation in progress will return an error.
+
+In any state "abort" stops any scans in progress (including paused scans) and
+the state goes to IDLE. Any configuration information is rest. Any motion will
+stop. A "scan" operation in progress will return an error.
+
+
+The current state appears in the device's structure along with the two
+position fields. Each field has a time stamp as well as a top-level time
+stamp.
 

--- a/pvDatabaseRPC/src/Makefile
+++ b/pvDatabaseRPC/src/Makefile
@@ -5,12 +5,15 @@ include $(TOP)/configure/CONFIG
 exampleRPCSRC = $(TOP)/src
 
 INC += pv/exampleRPC.h
+INC += pv/device.h
+INC += pv/point.h
 
 DBD += exampleRPCRegister.dbd
 
 LIBRARY = exampleRPC
 LIBSRCS += exampleRPC.cpp
 LIBSRCS += exampleRPCRegister.cpp
+LIBSRCS += device.cpp
 exampleRPC_LIBS += pvDatabase pvAccess pvData Com
 
 PROD_HOST += exampleRPCMain
@@ -18,9 +21,9 @@ exampleRPCMain_SRCS += exampleRPCMain.cpp
 exampleRPCMain_LIBS += exampleRPC
 exampleRPCMain_LIBS += pvDatabase pvAccess pvData Com
 
-PROD_HOST += move
-move_SRCS += positionClient.cpp
-move_LIBS += pvAccess pvData Com
+PROD_HOST += control
+control_SRCS += positionClient.cpp
+control_LIBS += pvAccess pvData Com
 
 
 include $(TOP)/configure/RULES

--- a/pvDatabaseRPC/src/device.cpp
+++ b/pvDatabaseRPC/src/device.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+/**
+ * @author Dave Hickin
+ *
+ */
+
+#include <pv/device.h>
+
+#include <epicsThread.h>
+
+#include <cmath>
+#include <sstream>
+
+namespace epics { namespace exampleCPP { namespace exampleRPC {
+
+
+DevicePtr Device::create()
+{
+    return DevicePtr(new Device());
+}
+
+std::string Device::toString(Device::State state)
+{
+    switch(state)
+    {
+    case IDLE:
+        return "IDLE";
+    case READY:
+        return "READY";
+    case RUNNING:
+        return "RUNNING";
+    case PAUSED:
+        return "PAUSED";
+     default:
+        throw std::runtime_error("Unknown state");
+    }
+}
+
+Device::State Device::getState()
+{
+    epics::pvData::Lock lock(mutex);
+    return state;
+}
+
+void Device::registerCallback(Callback::shared_pointer const & callback)
+{
+    epics::pvData::Lock lock(mutex);
+    if (find(callbacks.begin(),callbacks.end(), callback) != callbacks.end()) return;
+
+    callbacks.push_back(callback);
+}
+
+bool Device::unregisterCallback(Device::Callback::shared_pointer const & callback)
+{
+    epics::pvData::Lock lock(mutex);
+    std::vector<Callback::shared_pointer>::iterator foundCB
+        = find(callbacks.begin(),callbacks.end(), callback);
+    bool found = foundCB == callbacks.end();
+    callbacks.erase(foundCB);
+    return found;
+}
+
+void Device::setpointCallback(Point sp)
+{
+    epics::pvData::Lock lock(mutex);
+    std::vector<Callback::shared_pointer> callbacks = this->callbacks;
+    for (std::vector<Callback::shared_pointer>::iterator it = callbacks.begin();
+         it != callbacks.end(); ++it)
+       (*it)->setpointChanged(sp);
+}
+
+void Device::readCallback(Point rb)
+{
+    epics::pvData::Lock lock(mutex);
+    std::vector<Callback::shared_pointer> callbacks = this->callbacks;
+    for (std::vector<Callback::shared_pointer>::iterator it = callbacks.begin();
+         it != callbacks.end(); ++it)
+        (*it)->readbackChanged(rb);
+}
+
+void Device::stateCallback(State state)
+{
+    epics::pvData::Lock lock(mutex);
+    std::vector<Callback::shared_pointer> callbacks = this->callbacks;
+    for (std::vector<Callback::shared_pointer>::iterator it = callbacks.begin();
+         it != callbacks.end(); ++it)
+        (*it)->stateChanged(state);
+}
+
+void Device::scanComplete()
+{
+    epics::pvData::Lock lock(mutex);
+    std::vector<Callback::shared_pointer> callbacks = this->callbacks;
+    for (std::vector<Callback::shared_pointer>::iterator it = callbacks.begin();
+         it != callbacks.end(); ++it)
+        (*it)->scanComplete();
+}
+
+
+Device::Device()
+: state(IDLE), index(0)
+{
+   thread =  std::auto_ptr<epicsThread>(new epicsThread(
+        *this,
+        "device",
+        epicsThreadGetStackSize(epicsThreadStackSmall),
+        epicsThreadPriorityLow));
+        startThread();
+    }
+
+void Device::run()
+{
+    while (true)
+    {
+        try {
+            epicsThreadSleep(0.1);
+            epics::pvData::Lock lock(mutex);
+            if (state == IDLE || state == RUNNING)
+            {
+                if (positionRB != positionSP)
+                {
+                    double dx = positionSP.x - positionRB.x;
+                    double dy = positionSP.y - positionRB.y;
+
+                    const double ds = sqrt(dx*dx+dy*dy);
+                    const double maxds = 0.01;
+                    // avoid very small final steps
+                    const double maxds_x = maxds + 1.0e-5;
+
+                    if (ds > maxds_x)
+                    {
+                        double scale = maxds/ds;
+                        dx *= scale;
+                        dy *= scale;
+                        setReadbackImpl(Point(
+                            positionRB.x + dx, positionRB.y + dy));
+                    }
+                    else
+                    {
+                        setReadbackImpl(positionSP);
+                    }
+                }
+            }
+
+            if (state == RUNNING && positionRB == positionSP)
+            {
+                if (index < points.size())
+                {
+                    setSetpointImpl(points[index]);
+                    ++index;
+                }
+                else
+                {
+                    scanComplete();
+                    stopScan();
+                }
+            }
+            /*std::cout << toString(state) << " "
+                      << positionSP      << " "
+                      << positionRB      << " "
+                      << index    << std::endl;*/
+        }
+        catch (...) { abort(); }
+    }
+}
+
+Point Device::getPositionSetpoint()
+{
+    return positionSP;
+}
+
+Point Device::getPositionReadback()
+{
+    return positionRB;
+}
+
+
+void Device::setSetpoint(Point sp)
+{
+    if (state != IDLE)
+    {
+        std::stringstream ss;
+        ss << "Cannot set position setpoint unless device is IDLE. State is " << toString(state);
+        throw IllegalOperationException(ss.str());
+    }
+    setSetpointImpl(sp);
+}
+
+void Device::setSetpointImpl(Point sp)
+{
+    positionSP = sp;
+    setpointCallback(sp);
+}
+
+void Device::setReadbackImpl(Point rb)
+{
+    positionRB = rb;
+    readCallback(rb);
+}
+
+void Device::setStateImpl(State state)
+{
+    this->state = state;
+    stateCallback(state);  
+}
+
+
+void Device::abort()
+{
+    epics::pvData::Lock lock(mutex);
+    std::cout << "Abort" << std::endl;
+    setStateImpl(IDLE);
+    points.clear();
+    if (positionSP != positionRB)
+        setSetpointImpl(positionRB);
+}
+
+void Device::configure(const std::vector<Point> & newPoints)
+{
+    epics::pvData::Lock lock(mutex);
+    if (state != IDLE)
+    {
+        std::stringstream ss;
+        ss << "Cannot configure device unless it is IDLE. State is " << toString(state);
+        throw IllegalOperationException(ss.str());
+
+    }
+    std::cout << "Configure" << std::endl;
+    setStateImpl(READY);
+    points = newPoints;
+
+    if (positionSP != positionRB)
+        setSetpointImpl(positionRB);
+}
+
+void Device::runScan()
+{
+    epics::pvData::Lock lock(mutex);
+    if (state != READY)
+    {
+        std::stringstream ss;
+        ss << "Cannot run device unless it is READY. State is " << toString(state);
+        throw IllegalOperationException(ss.str());
+    }
+    std::cout << "Run" << std::endl;
+    index = 0;
+    setStateImpl(RUNNING);
+}
+
+void Device::pause()
+{
+    epics::pvData::Lock lock(mutex);
+    if (state != RUNNING) 
+    {
+        std::stringstream ss;
+        ss << "Cannot pause device unless it is RUNNING. State is " << toString(state);
+        throw IllegalOperationException(ss.str());
+    }
+    std::cout << "Pause" << std::endl;
+    setStateImpl(PAUSED);
+ }
+
+void Device::resume()
+{
+    epics::pvData::Lock lock(mutex);
+    if (state != PAUSED) 
+    {
+        std::stringstream ss;
+        ss << "Cannot resume device unless it is PAUSED. State is " << toString(state);
+        throw IllegalOperationException(ss.str());
+    }
+    std::cout << "Resume" << std::endl;
+    setStateImpl(RUNNING);
+
+}
+
+void Device::stopScan()
+{
+    epics::pvData::Lock lock(mutex);
+    switch (state)
+    {
+    case RUNNING:
+    case PAUSED:
+    case READY:
+        std::cout << "Stop" << std::endl;
+        setStateImpl(READY);
+        if (positionSP != positionRB)
+            setSetpointImpl(positionRB);
+        break;
+    default:
+        {
+            std::stringstream ss;
+            ss << "Cannot stop device unless it is RUNNING, PAUSED or READY. State is " << toString(state);
+            throw IllegalOperationException(ss.str());
+        }
+    }
+}
+
+void Device::rewind(int n)
+{
+    epics::pvData::Lock lock(mutex);
+    switch (state)
+    {
+    case RUNNING:
+    case PAUSED:
+        if (n < 0)
+        {
+            std::stringstream ss;
+            ss << "Rewind argument cannot be negative. Argument is " << n;
+            throw IllegalOperationException(ss.str());
+        }
+        if (n > 0)
+        {
+            unsigned un = static_cast<unsigned>(n);
+            std::cout << "Rewind(" << n << ")" << std::endl;
+            if (un < index)
+                index -= un+1;
+            else
+                index = 0;
+            setSetpointImpl(points[index]);
+            ++index;
+        }
+            break;
+    default:
+            {
+            std::stringstream ss;
+            ss << "Cannot rewind device unless it is RUNNING or PAUSED. State is " << toString(state);
+            throw IllegalOperationException(ss.str());
+        }
+    }
+}
+
+}}}
+
+

--- a/pvDatabaseRPC/src/exampleRPC.cpp
+++ b/pvDatabaseRPC/src/exampleRPC.cpp
@@ -18,6 +18,7 @@
 
 #include <epicsThread.h>
 
+
 using namespace epics::pvData;
 using namespace epics::pvDatabase;
 using std::tr1::static_pointer_cast;
@@ -26,18 +27,91 @@ using std::string;
 namespace epics { namespace exampleCPP { namespace exampleRPC { 
 
 
-PVStructurePtr ExampleRPCService::request(
+static StructureConstPtr makeResultStructure()
+{
+    static StructureConstPtr resultStructure;
+    if (resultStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        resultStructure = fieldCreate->createFieldBuilder()->
+            createStructure();
+    }
+
+    return resultStructure;
+}
+
+static StructureConstPtr makePointStructure()
+{
+    static StructureConstPtr pointStructure;
+    if (pointStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        pointStructure = fieldCreate->createFieldBuilder()->
+            setId("point_t")->
+            add("x",pvDouble)->
+            add("y",pvDouble)->
+            createStructure();
+    }
+
+    return pointStructure;
+}
+
+static StructureConstPtr makePointTopStructure()
+{
+    static StructureConstPtr pointStructure;
+    if (pointStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        pointStructure = fieldCreate->createFieldBuilder()->
+            setId("Point")->
+            add("value", makePointStructure())->
+            add("timeStamp", getStandardField()->timeStamp())->
+            createStructure();
+    }
+    return pointStructure;
+}
+
+static StructureConstPtr makeRecordStructure()
+{
+    static StructureConstPtr recordStructure;
+    if (recordStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        recordStructure = fieldCreate->createFieldBuilder()->
+            add("positionSP", makePointTopStructure())->
+            add("positionRB", makePointTopStructure())->
+            add("state", getStandardField()->enumerated("timeStamp"))->
+            add("timeStamp", getStandardField()->timeStamp())->
+            createStructure();
+    }
+    return recordStructure;
+}
+
+
+
+PVStructurePtr AbortService::request(
     PVStructure::shared_pointer const & args
 ) throw (epics::pvAccess::RPCRequestException)
 {
-    bool haveControl = pvRecord->takeControl();
-    if (!haveControl)
-        throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
-            "I'm busy");
+    try {
+        pvRecord->device->abort();
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
 
-    FieldCreatePtr fieldCreate = getFieldCreate();
-    PVDataCreatePtr pvDataCreate = getPVDataCreate();
 
+PVStructurePtr ConfigureService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
     PVStructureArrayPtr valueField = args->getSubField<PVStructureArray>("value");
     if (valueField.get() == 0)
         throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
@@ -57,73 +131,240 @@ PVStructurePtr ExampleRPCService::request(
             "value field's structure has no double field y");
 
     PVStructureArray::const_svector vals = valueField->view();
-
+    
+    std::vector<Point> newPoints;
+    newPoints.reserve(vals.size());
     for (PVStructureArray::const_svector::const_iterator it = vals.begin();
          it != vals.end(); ++it)
     {
         double x = (*it)->getSubFieldT<PVDouble>("x")->get();
         double y = (*it)->getSubFieldT<PVDouble>("y")->get();
-        pvRecord->put(x,y);
-        epicsThreadSleep(1.0);
+        newPoints.push_back(Point(x,y));
     }
 
-    StructureConstPtr  topStructure = fieldCreate->createFieldBuilder()->
-        createStructure();
-
-    PVStructurePtr returned = pvDataCreate->createPVStructure(topStructure);
-    pvRecord->releaseControl();
-    return returned;
+    try {
+        pvRecord->device->configure(newPoints);
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
 }
 
-void ExampleRPCServiceAsync::request(
-    epics::pvData::PVStructurePtr const & args,
+PVStructurePtr RunService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
+    try {
+        pvRecord->device->runScan();
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
+
+
+PVStructurePtr PauseService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
+    try {
+        pvRecord->device->pause();
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
+
+PVStructurePtr ResumeService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
+    try {
+        pvRecord->device->resume();
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
+
+PVStructurePtr StopService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
+    try {
+        pvRecord->device->stopScan();
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
+
+
+int RewindService::getRequestedSteps(PVStructurePtr const & args)
+{
+    PVIntPtr valueField = args->getSubField<PVInt>("value");
+    if (valueField.get() == NULL)
+        throw epics::pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
+            "No int value field");
+
+    return valueField->get();
+}
+
+PVStructurePtr RewindService::request(
+    PVStructure::shared_pointer const & args
+) throw (epics::pvAccess::RPCRequestException)
+{
+    int n = getRequestedSteps(args);
+    try {
+        pvRecord->device->rewind(n);
+    }
+    catch (IllegalOperationException & e) {
+        throw epics::pvAccess::RPCRequestException(
+            Status::STATUSTYPE_ERROR,e.what());
+    }
+    return getPVDataCreate()->createPVStructure(makeResultStructure());
+}
+
+
+ScanService::Callback::shared_pointer ScanService::Callback::create(ScanServicePtr const & service)
+{
+    return ScanService::Callback::shared_pointer(new ScanService::Callback(service));
+}
+
+void ScanService::request(
+    PVStructurePtr const & args,
     epics::pvAccess::RPCResponseCallback::shared_pointer const & callback)
 {
-    bool haveControl = pvRecord->takeControl();
-    if (!haveControl)
-        throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
-            "I'm busy");
+    pvRecord->device->runScan();
+    ScanService::Callback::shared_pointer cb = ScanService::Callback::create(shared_from_this());
+    cb->callback = callback;
+    pvRecord->device->registerCallback(cb);
+}
+ 
 
-    FieldCreatePtr fieldCreate = getFieldCreate();
-    PVDataCreatePtr pvDataCreate = getPVDataCreate();
-
-    PVStructureArrayPtr valueField = args->getSubField<PVStructureArray>("value");
-    if (valueField.get() == 0)
-        throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
-            "No structure array value field");
-
-    StructureConstPtr valueFieldStructure = valueField->
-        getStructureArray()->getStructure();
-
-    ScalarConstPtr xField = valueFieldStructure->getField<Scalar>("x");
-    if (xField.get() == 0 || xField->getScalarType() != pvDouble)
-        throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
-            "value field's structure has no double field x");
-
-    ScalarConstPtr yField = valueFieldStructure->getField<Scalar>("y");
-    if (yField.get() == 0 || yField->getScalarType() != pvDouble)
-        throw pvAccess::RPCRequestException(Status::STATUSTYPE_ERROR,
-            "value field's structure has no double field y");
-
-    PVStructureArray::const_svector vals = valueField->view();
-
-    for (PVStructureArray::const_svector::const_iterator it = vals.begin();
-         it != vals.end(); ++it)
+void ScanService::Callback::stateChanged(Device::State state)
+{
+    if (state == Device::READY)
     {
-        double x = (*it)->getSubFieldT<PVDouble>("x")->get();
-        double y = (*it)->getSubFieldT<PVDouble>("y")->get();
-        pvRecord->put(x,y);
-        epicsThreadSleep(1.0);
+        handleError("Scan was stopped");
     }
-
-    StructureConstPtr  topStructure = fieldCreate->createFieldBuilder()->
-        createStructure();
-
-    PVStructurePtr returned = pvDataCreate->createPVStructure(topStructure);
-    pvRecord->releaseControl();
-    callback->requestDone(Status::Ok, returned);
+    else if (state == Device::IDLE)
+    {
+        handleError("Scan was aborted");
+    }
 }
 
+void ScanService::Callback::handleError(const std::string & message)
+{
+    callback->requestDone(
+        Status(Status::STATUSTYPE_ERROR, std::string(message)),
+        PVStructure::shared_pointer());
+
+    service->pvRecord->device->unregisterCallback(shared_from_this());
+}
+
+void ScanService::Callback::scanComplete()
+{
+    callback->requestDone(Status::Ok, getPVDataCreate()->createPVStructure(makeResultStructure()));
+    service->pvRecord->device->unregisterCallback(shared_from_this());
+}
+
+
+ExampleRPC::Callback::shared_pointer ExampleRPC::Callback::create(ExampleRPCPtr const & record)
+{
+    return ExampleRPC::Callback::shared_pointer(new ExampleRPC::Callback(record));
+}
+
+void ExampleRPC::Callback::setpointChanged(Point sp)
+{
+    record->setpointChanged(sp);
+}
+
+void ExampleRPC::setpointChanged(Point sp)
+{
+    lock();
+    try {
+        TimeStamp timeStamp;
+        timeStamp.getCurrent();
+        beginGroupPut();
+        pvx->put(sp.x);
+        pvy->put(sp.y);
+        pvTimeStamp_sp.set(timeStamp);
+        pvTimeStamp.set(timeStamp);
+        endGroupPut();
+    }
+    catch(...)
+    {
+        unlock();
+        throw;
+    }
+    unlock();
+}
+
+void ExampleRPC::Callback::readbackChanged(Point rb)
+{
+    record->readbackChanged(rb);
+}
+
+void ExampleRPC::readbackChanged(Point rb)
+{
+    lock();
+    try {
+        TimeStamp timeStamp;
+        timeStamp.getCurrent();
+        beginGroupPut();
+        pvx_rb->put(rb.x);
+        pvy_rb->put(rb.y);
+        pvTimeStamp_rb.set(timeStamp);
+        pvTimeStamp.set(timeStamp);
+        endGroupPut();
+    }
+    catch(...)
+    {
+        unlock();
+        throw;
+    }
+    unlock();
+}
+
+void ExampleRPC::Callback::stateChanged(Device::State state)
+{
+    record->stateChanged(state);
+}
+
+void ExampleRPC::stateChanged(Device::State state)
+{
+    lock();
+    try {
+        TimeStamp timeStamp;
+        timeStamp.getCurrent();
+        beginGroupPut();
+        int index = static_cast<int>(device->getState());
+        if (index != pvStateIndex->get())
+        {
+            pvTimeStamp_st.set(timeStamp);
+            pvStateIndex->put(index);
+        }
+        pvTimeStamp.set(timeStamp);
+        endGroupPut();
+        }
+        catch(...)
+        {
+            unlock();
+            throw;
+        }
+    unlock();
+}
 
 
 ExampleRPCPtr ExampleRPC::create(
@@ -132,12 +373,8 @@ ExampleRPCPtr ExampleRPC::create(
     StandardFieldPtr standardField = getStandardField();
     FieldCreatePtr fieldCreate = getFieldCreate();
     PVDataCreatePtr pvDataCreate = getPVDataCreate();
-    StructureConstPtr  topStructure = fieldCreate->createFieldBuilder()->
-        add("x",pvDouble)->
-        add("y",pvDouble)->
-        add("timeStamp",standardField->timeStamp()) ->
-        createStructure();
-    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(topStructure);
+
+    PVStructurePtr pvStructure = pvDataCreate->createPVStructure(makeRecordStructure());
 
     ExampleRPCPtr pvRecord(
         new ExampleRPC(recordName,pvStructure));
@@ -148,53 +385,155 @@ ExampleRPCPtr ExampleRPC::create(
 ExampleRPC::ExampleRPC(
     string const & recordName,
     PVStructurePtr const & pvStructure)
-: PVRecord(recordName,pvStructure)
-{    
+: PVRecord(recordName,pvStructure), firstTime(true)
+{
+    pvx    = pvStructure->getSubFieldT<PVDouble>("positionSP.value.x");
+    pvy    = pvStructure->getSubFieldT<PVDouble>("positionSP.value.y");
+    pvx_rb = pvStructure->getSubFieldT<PVDouble>("positionRB.value.x");
+    pvy_rb = pvStructure->getSubFieldT<PVDouble>("positionRB.value.y");
+
+    pvStateIndex = pvStructure->getSubFieldT<PVInt>("state.value.index");
+    pvStateChoices = pvStructure->getSubFieldT<PVStringArray>("state.value.choices");
+
+    pvTimeStamp.attach(pvStructure->getSubFieldT<PVStructure>("timeStamp"));
+    pvTimeStamp_sp.attach(pvStructure->getSubFieldT<PVStructure>("positionSP.timeStamp"));
+    pvTimeStamp_rb.attach(pvStructure->getSubFieldT<PVStructure>("positionRB.timeStamp"));
+        pvTimeStamp_st.attach(pvStructure->getSubFieldT<PVStructure>("state.timeStamp"));
+
+    PVStringArray::svector choices;
+    choices.reserve(4);
+    choices.push_back(Device::toString(Device::IDLE));
+    choices.push_back(Device::toString(Device::READY));
+    choices.push_back(Device::toString(Device::RUNNING));
+    choices.push_back(Device::toString(Device::PAUSED));
+    pvStateChoices->replace(freeze(choices));
+
+    device = Device::create();
 }
 
 void ExampleRPC::initPvt()
 {
-    
     initPVRecord();
-
-    service = ExampleRPCService::create(
-        std::tr1::dynamic_pointer_cast<ExampleRPC>(
-            shared_from_this()));
 
     PVFieldPtr pvField;
     pvTimeStamp.attach(getPVStructure()->getSubField("timeStamp"));
+
+    device->registerCallback(Callback::create(std::tr1::dynamic_pointer_cast<ExampleRPC>(shared_from_this())));
+
+    process();
 }
 
 epics::pvAccess::Service::shared_pointer ExampleRPC::getService(
-        PVStructurePtr const & /*pvRequest*/)
+        PVStructurePtr const & pvRequest)
 {
-    return service;
-}
+    PVStringPtr methodField = pvRequest->getSubField<PVString>("method");
 
-bool ExampleRPC::takeControl()
-{
-    return taskMutex.tryLock();
-}
-
-void ExampleRPC::releaseControl()
-{
-    taskMutex.unlock();
-}
-
-void ExampleRPC::put(double x, double y)
-{
-    lock();
-    beginGroupPut();
-    getPVStructure()->getSubField<PVDouble>("x")->put(x);
-    getPVStructure()->getSubField<PVDouble>("y")->put(y);
-    process();
-    endGroupPut();
-    unlock();
+    if (methodField.get() != 0)
+    {
+        std::string method = methodField->get();
+        if (method == "abort")
+        {
+             return AbortService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "configure")
+        {
+            return ConfigureService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "run")
+        {
+            return RunService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "resume")
+        {
+            return ResumeService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "pause")
+        {
+            return PauseService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "stop")
+        {
+            return StopService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method == "rewind")
+        {
+            return RewindService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+        else if (method  == "scan")
+        {
+            return ScanService::create(
+                 std::tr1::dynamic_pointer_cast<ExampleRPC>(
+                 shared_from_this()));
+        }
+    }
+    return epics::pvAccess::Service::shared_pointer();
 }
 
 void ExampleRPC::process()
 {
-    PVRecord::process();
+    TimeStamp timeStamp;
+    timeStamp.getCurrent();
+
+    Point newSP = Point(pvx->get(), pvy->get()); 
+    try
+    {
+        Point sp_initial = device->getPositionSetpoint();
+      
+        if (sp_initial != newSP)
+        {
+            device->setSetpoint(newSP);
+            pvTimeStamp_sp.set(timeStamp);
+        }
+    }
+    catch (IllegalOperationException & o)
+    {
+        // If write to device fails restore values
+        Point sp = device->getPositionSetpoint();
+        if (sp != newSP)
+        {
+            pvx->put(sp.x);
+            pvy->put(sp.y);
+        }
+    }
+
+    // If readback is written to, restore value
+    Point device_rb = device->getPositionReadback();
+    Point record_rb = Point(pvx_rb->get(), pvx_rb->get());
+    if (record_rb != device_rb)
+    {
+        pvx_rb->put(device_rb.x);
+        pvy_rb->put(device_rb.y);        
+    }
+
+    // If state is written to, restore value
+    int index = static_cast<int>(device->getState());
+    if (index != pvStateIndex->get())
+    {
+        pvStateIndex->put(index);
+    }
+
+    if (firstTime) {
+        pvTimeStamp_sp.set(timeStamp);
+        pvTimeStamp_rb.set(timeStamp);
+        pvTimeStamp_st.set(timeStamp);
+        firstTime = false;
+    }
+
+    pvTimeStamp.set(timeStamp);
 }
 
 

--- a/pvDatabaseRPC/src/positionClient.cpp
+++ b/pvDatabaseRPC/src/positionClient.cpp
@@ -14,24 +14,7 @@
 
 using namespace epics::pvData;
 
-
-static StructureConstPtr makeDeviceStructure()
-{
-    static StructureConstPtr deviceStructure;
-    if (deviceStructure.get() == 0)
-    {
-        FieldCreatePtr fieldCreate = getFieldCreate();
-
-        deviceStructure = fieldCreate->createFieldBuilder()->
-            add("x",pvDouble)->
-            add("y",pvDouble)->
-            createStructure();
-    }
-    return deviceStructure;
-}
-
-
-static StructureConstPtr makeArgumentStructure()
+static StructureConstPtr makeRequestStructure()
 {
     static StructureConstPtr requestStructure;
     if (requestStructure.get() == 0)
@@ -39,31 +22,271 @@ static StructureConstPtr makeArgumentStructure()
         FieldCreatePtr fieldCreate = getFieldCreate();
 
         requestStructure = fieldCreate->createFieldBuilder()->
-            addArray("value", makeDeviceStructure())->
+            add("method", pvString)->
             createStructure();
     }
     return requestStructure;
 }
 
+static StructureConstPtr makePointStructure()
+{
+    static StructureConstPtr pointStructure;
+    if (pointStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        pointStructure = fieldCreate->createFieldBuilder()->
+            setId("point_t")->
+            add("x",pvDouble)->
+            add("y",pvDouble)->
+            createStructure();
+    }
+    return pointStructure;
+}
+
+static StructureConstPtr makeArgumentStructure()
+{
+    static StructureConstPtr argStructure;
+    if (argStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        argStructure = fieldCreate->createFieldBuilder()->
+            createStructure();
+    }
+    return argStructure;
+}
+
+static StructureConstPtr makeRewindArgumentStructure()
+{
+    static StructureConstPtr argStructure;
+    if (argStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        argStructure = fieldCreate->createFieldBuilder()->
+            add("value", pvInt)->
+            createStructure();
+    }
+    return argStructure;
+}
+
+static StructureConstPtr makeConfigureArgumentStructure()
+{
+    static StructureConstPtr argStructure;
+    if (argStructure.get() == 0)
+    {
+        FieldCreatePtr fieldCreate = getFieldCreate();
+
+        argStructure = fieldCreate->createFieldBuilder()->
+            addArray("value", makePointStructure())->
+            createStructure();
+    }
+    return argStructure;
+}
+
 // Set a pvAccess connection timeout, after which the client gives up trying 
 // to connect to server.
-const static double REQUEST_TIMEOUT = 3.0;
+const static double DEFAULT_TIMEOUT = 3.0;
 const static std::string DEVICE_NAME = "mydevice";
-const static std::string APP_NAME = "move";
+const static std::string APP_NAME = "control";
+
+
+
+void usage_help() {
+    std::cout <<  "Usage:\n"
+              <<  "For help on commands run supplying the arguments:\n"
+              <<  "help <command>\n"
+              <<  std::endl;
+    }
+
+void usage_configure()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the arguments:\n"
+              <<  "configure x_1 y_1 [x_2 y_2] ... [x_n y_n]\n"
+              <<  "Sets the sequence of points through which "
+              <<  DEVICE_NAME + " will move\n"
+              <<  "to (x_i,y_i), i = 1..n"
+              <<  " and changes state to READY.\n"
+              <<  "Device must be IDLE.\n"
+              <<  std::endl;
+}
+
+void usage_run()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "run\n"
+              <<  "Starts the device moving through the sequence of points supplied on\n"
+              <<  "configuration, changes state to RUNNING and returns.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Device must be READY.\n"
+              <<  std::endl;
+}
+
+void usage_scan()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "scan\n"
+              <<  "Starts the device moving through the sequence of points supplied on\n"
+              <<  "configuration, changes state to RUNNING and blocks until completion.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Returns an error if scan is stopped or aborted.\n"
+              <<  "Device must be READY.\n"
+              <<  std::endl;
+}
+
+void usage_pause()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "pause\n"
+              <<  "Pauses the current scan and changes state to PAUSED.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Device must be RUNNING.\n"
+              <<  std::endl;
+}
+
+void usage_resume()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "resume\n"
+              <<  "Resumes the current scan and changes state to RUNNING.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Device must be PAUSED.\n"
+              <<  std::endl;
+}
+
+void usage_rewind()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the arguments:\n"
+              <<  "rewind <steps>\n"
+              <<  "Rewinds the current scan the requested number of steps or to start.\n"
+              <<  "Required argument is the number of steps, which must be non-negative.\n"
+              <<  "Device must be RUNNING or PAUSED.\n"
+              <<  std::endl;
+}
+
+void usage_stop()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "stop\n"
+              <<  "Stops any scan in progress and changes state to READY.\n"
+              <<  "Blocking scan operation in progress will return an error.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Device can be any state except IDLE.\n"
+              <<  std::endl;
+}
+
+void usage_abort()
+{
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the argument:\n"
+              <<  "abort\n"
+              <<  "Aborts any scan or motion in progress and changes state to IDLE.\n"
+              <<  "Blocking scan operation in progress will return an error.\n"
+              <<  "No additional arguments are required.\n"
+              <<  "Device can be any state.\n"
+              <<  std::endl;
+}
+
+void usage();
+
+void usage(const std::string & command)
+{
+    if (command == std::string("configure"))
+            usage_configure();
+    else if (command == std::string("run"))
+            usage_run();
+    else if (command == std::string("scan"))
+            usage_scan();
+    else if (command == std::string("pause"))
+            usage_pause();
+    else if (command == std::string("resume"))
+            usage_resume();
+    else if (command == std::string("rewind"))
+            usage_rewind();
+    else if (command == std::string("stop"))
+            usage_stop();
+    else if (command == std::string("abort"))
+            usage_abort();
+    else if (command == std::string("help"))
+            usage_help();
+    else
+    {
+        std::cout << "Unknown command " << command;
+        usage();
+    }
+}
+
+
 
 void usage()
 {
-    std::cout << "Usage: " << APP_NAME << " [x_1 y_1] ... [x_n y_n]\n"
-              << "Sequentially sets the values of the x and y fields of "
-              << DEVICE_NAME << " to (x_i,y_i).\n"
-              << "Returns on completion."
-              << std::endl;
+    std::cout <<  "Usage:\n"
+              <<  "Run application supplying the arguments:\n"
+              <<  " <command> [<command-arguments>]\n"
+              <<  "Controls a device (" + DEVICE_NAME + ")\n" 
+              <<  "Available commands are:\n"
+              <<  "help\n"
+              <<  "configure\n"
+              <<  "run\n"
+              <<  "pause\n"
+              <<  "resume\n"
+              <<  "rewind\n"
+              <<  "stop\n"
+              <<  "scan\n"
+              <<  "abort.\n"
+              << "<command-arguments> is command-dependent.\n"
+              <<  "For help on commands run supplying the arguments:\n"
+              <<  "help <command>\n"
+              <<  std::endl;
+}
+
+
+PVStructurePtr createRewindArgs(const std::string & arg)
+{
+    PVStructurePtr arguments(getPVDataCreate()->createPVStructure(makeRewindArgumentStructure()));
+
+    arguments->getSubFieldT<PVInt>("value")->put(atoi(arg.c_str()));
+    return arguments;
+}
+
+
+PVStructurePtr createConfigArgs(int argc, char *argv[])
+{
+    PVStructurePtr arguments(getPVDataCreate()->createPVStructure(makeConfigureArgumentStructure()));
+
+    PVStructureArray::svector values;
+
+    for (int i = 2; i < argc; )
+    {
+        PVStructurePtr point(getPVDataCreate()->createPVStructure(makePointStructure()));
+        point->getSubField<PVDouble>("x")->put(atof(argv[i++]));
+        point->getSubField<PVDouble>("y")->put(atof(argv[i++]));
+        values.push_back(point);
+    }
+
+	arguments->getSubField<PVStructureArray>("value")->replace(freeze(values));
+std::cout << "createConfigArgs\n" << arguments << std::endl;
+    return arguments;
 }
 
 /**
   */
 int main (int argc, char *argv[])
 {
+    if (argc < 2)
+    {
+        usage();
+        return 1;
+    }
+
     for (int i = 1; i < argc; ++i)
     {
         std::string arg(argv[i]);
@@ -72,39 +295,76 @@ int main (int argc, char *argv[])
             usage();
             return 0;
         }
-    } 
-
-    if ((argc % 2) != 1)
-    {
-        std::cerr << APP_NAME << " requires an even number of arguments."
-                  << std::endl;
-        usage();
-        return 1;
     }
-    // Start the pvAccess client side.
-    epics::pvAccess::ClientFactory::start();
 
-    try
+    std::string command(argv[1]);
+
+    if (command == std::string("help"))
     {
-        PVStructurePtr arguments(getPVDataCreate()->createPVStructure(makeArgumentStructure()));
-
-        PVStructureArray::svector values;
-
-        for (int i = 1; i < argc; )
+        if(argc < 3)
         {
-            PVStructurePtr point(getPVDataCreate()->createPVStructure(makeDeviceStructure()));
-            point->getSubField<PVDouble>("x")->put(atof(argv[i++]));
-            point->getSubField<PVDouble>("y")->put(atof(argv[i++]));
-            values.push_back(point);
+            usage();
+            return 0;
+        }
+        else
+        {
+            usage(argv[2]);
+            return 0;
+        }
+    }
+
+    if (command == std::string("configure"))
+    {
+        if(argc < 4)
+        {
+            std::cerr << "configure  must have at least one pair of position coordinate arguments." << std::endl;
+            usage_configure();
+            return 1;
         }
 
-	    arguments->getSubField<PVStructureArray>("value")->replace(freeze(values));
+        if ((argc % 2) != 0)
+        {
+            std::cerr << "configure requires an even number of arguments."
+                      <<  std::endl;
+            usage_configure();
+            return 1;
+        }
+    }
+
+    if (command == std::string("rewind") && argc < 3)
+    {
+        std::cerr << "rewind requires an argument." <<  std::endl;
+        usage_rewind();
+        return 1;
+    }
+
+    PVDataCreatePtr pvDataCreate = getPVDataCreate();
+
+    PVStructurePtr pvArguments;
+    if (command == std::string("configure"))
+        pvArguments = createConfigArgs(argc, argv);
+    else if (command == std::string("rewind"))
+        pvArguments = createRewindArgs(argv[2]);
+    else
+        pvArguments = pvDataCreate->createPVStructure(makeArgumentStructure());
+
+    // Start the pvAccess client side.
+    epics::pvAccess::ClientFactory::start();
+    try
+    {
+        PVStructureArray::svector values;
+
+        PVStructurePtr pvRequest = getPVDataCreate()->createPVStructure(makeRequestStructure());
+        pvRequest->getSubFieldT<PVString>("method")->put(command);
 
         epics::pvAccess::RPCClient::shared_pointer client
-             = epics::pvAccess::RPCClient::create(DEVICE_NAME);
+             = epics::pvAccess::RPCClient::create(DEVICE_NAME, pvRequest);
 
-        PVStructurePtr response = client->request(arguments,
-            REQUEST_TIMEOUT + 1.0 * (argc/2));
+        double timeout = DEFAULT_TIMEOUT;
+        if (command == std::string("scan"))
+            timeout = 1e9;
+
+        PVStructurePtr response = client->request(pvArguments, timeout);
 
         std::cout << "Done" << std::endl;
     }

--- a/pvDatabaseRPC/src/pv/device.h
+++ b/pvDatabaseRPC/src/pv/device.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+/**
+ * @author Dave Hickin
+ *
+ */
+
+#ifndef EXAMPLERPC_DEVICE_H
+#define EXAMPLERPC_DEVICE_H
+
+
+#ifdef epicsExportSharedSymbols
+#   define deviceExportSharedSymbols
+#   undef epicsExportSharedSymbols
+#endif
+
+#include <pv/pvDatabase.h>
+
+#include <pv/point.h>
+
+#include <epicsThread.h>
+
+#ifdef deviceExportSharedSymbols
+#   define epicsExportSharedSymbols
+#	undef deviceExportSharedSymbols
+#endif
+
+#include <shareLib.h>
+
+
+namespace epics { namespace exampleCPP { namespace exampleRPC {
+
+epicsShareClass class IllegalOperationException : public std::runtime_error
+{
+public:
+    IllegalOperationException(const std::string & message)
+    : runtime_error(message)
+    {
+    }
+};
+
+class Device;
+typedef std::tr1::shared_ptr<Device> DevicePtr;
+
+epicsShareClass class Device : public epicsThreadRunable,
+    public std::tr1::enable_shared_from_this<Device>
+{
+public:
+    static DevicePtr create();
+
+    POINTER_DEFINITIONS(Device);
+
+    enum State {
+        IDLE, READY, RUNNING, PAUSED
+    };
+
+    static std::string toString(State state);
+
+    State getState();
+
+    virtual bool init() { return false;}
+    virtual void run();
+    void startThread() { thread->start(); }
+    void stop() {}
+
+   class Callback : public std::tr1::enable_shared_from_this<Callback>
+   {
+   public:
+       POINTER_DEFINITIONS(Callback);
+
+       virtual void setpointChanged(Point sp) {}
+       virtual void readbackChanged(Point rb){}
+       virtual void stateChanged(State state) {}
+       virtual void scanComplete() {}
+   };
+
+    void registerCallback(Callback::shared_pointer const & callback);
+
+    bool unregisterCallback(Callback::shared_pointer const & callback);
+
+    void setpointCallback(Point sp);
+
+    void readCallback(Point rb);
+
+    void stateCallback(State state);
+
+    void scanComplete();
+
+    Point getPositionSetpoint();
+
+    Point getPositionReadback();
+
+    void setSetpoint(Point sp);
+
+    void abort();
+
+    void configure(const std::vector<Point> & newPoints);
+
+    void runScan();
+
+    void pause();
+
+    void resume();
+
+    void stopScan();
+
+    void rewind(int n);
+
+private:
+    Device();
+
+    void setSetpointImpl(Point sp);
+
+    void setReadbackImpl(Point rb);
+
+    void setStateImpl(State state);
+
+    State state;
+
+    Point positionSP;
+    Point positionRB;
+
+    std::vector<Callback::shared_pointer> callbacks;
+
+    size_t index;
+
+    std::vector<Point> points;
+
+    epics::pvData::Mutex mutex;
+    std::auto_ptr<epicsThread> thread;
+};
+
+}}}
+
+#endif // EXAMPLERPC_DEVICE_H
+

--- a/pvDatabaseRPC/src/pv/exampleRPC.h
+++ b/pvDatabaseRPC/src/pv/exampleRPC.h
@@ -19,6 +19,8 @@
 #include <pv/timeStamp.h>
 #include <pv/pvTimeStamp.h>
 
+#include <pv/device.h>
+
 #ifdef exampleRPCEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
 #	undef exampleRPCEpicsExportSharedSymbols
@@ -29,11 +31,30 @@
 
 namespace epics { namespace exampleCPP { namespace exampleRPC { 
 
-class ExampleRPCService;
-typedef std::tr1::shared_ptr<ExampleRPCService> ExampleRPCServicePtr;
 
-class ExampleRPCServiceAsync;
-typedef std::tr1::shared_ptr<ExampleRPCServiceAsync> ExampleRPCServiceAsyncPtr;
+class AbortService;
+typedef std::tr1::shared_ptr<AbortService> AbortServicePtr;
+
+class ConfigureService;
+typedef std::tr1::shared_ptr<ConfigureService> ConfigureServicePtr;
+
+class RunService;
+typedef std::tr1::shared_ptr<RunService> RunServicePtr;
+
+class PauseService;
+typedef std::tr1::shared_ptr<PauseService> PauseServicePtr;
+
+class ResumeService;
+typedef std::tr1::shared_ptr<ResumeService> ResumeServicePtr;
+
+class StopService;
+typedef std::tr1::shared_ptr<StopService> StopServicePtr;
+
+class RewindService;
+typedef std::tr1::shared_ptr<RewindService> RewindServicePtr;
+
+class ScanService;
+typedef std::tr1::shared_ptr<ScanService> ScanServicePtr;
 
 
 class ExampleRPC;
@@ -41,23 +62,25 @@ typedef std::tr1::shared_ptr<ExampleRPC> ExampleRPCPtr;
 
 
 
-class epicsShareClass ExampleRPCService :
+
+
+class epicsShareClass AbortService :
     public virtual epics::pvAccess::RPCService
 {
 public:
-    POINTER_DEFINITIONS(ExampleRPCService);
+    POINTER_DEFINITIONS(AbortService);
 
-    static ExampleRPCService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    static AbortService::shared_pointer create(ExampleRPCPtr const & pvRecord)
     {
-        return ExampleRPCServicePtr(new ExampleRPCService(pvRecord));
+        return AbortServicePtr(new AbortService(pvRecord));
     }
-    ~ExampleRPCService() {};
+    ~AbortService() {};
  
     epics::pvData::PVStructurePtr request(
         epics::pvData::PVStructure::shared_pointer const & args
     ) throw (epics::pvAccess::RPCRequestException);
 private:
-    ExampleRPCService(ExampleRPCPtr const & pvRecord)
+    AbortService(ExampleRPCPtr const & pvRecord)
     : pvRecord(pvRecord)
     {
     }
@@ -66,21 +89,205 @@ private:
 };
 
 
-class ExampleRPCServiceAsync :
-    public epics::pvAccess::RPCServiceAsync
+class epicsShareClass ConfigureService :
+    public virtual epics::pvAccess::RPCService
 {
 public:
-    POINTER_DEFINITIONS(ExampleRPCServiceAsync);
+    POINTER_DEFINITIONS(ConfigureService);
 
-    static ExampleRPCServiceAsync::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    static ConfigureService::shared_pointer create(ExampleRPCPtr const & pvRecord)
     {
-        return ExampleRPCServiceAsyncPtr(new ExampleRPCServiceAsync(pvRecord));
+        return ConfigureServicePtr(new ConfigureService(pvRecord));
+    }
+    ~ConfigureService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+private:
+    ConfigureService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+
+class epicsShareClass RunService :
+    public virtual epics::pvAccess::RPCService
+{
+public:
+    POINTER_DEFINITIONS(RunService);
+
+    static RunService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return RunServicePtr(new RunService(pvRecord));
+    }
+    ~RunService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+private:
+    RunService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+class PauseService :
+    public virtual epics::pvAccess::RPCService
+{
+public:
+    POINTER_DEFINITIONS(PauseService);
+
+    static PauseService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return PauseServicePtr(new PauseService(pvRecord));
+    }
+    ~PauseService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+private:
+    PauseService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+class ResumeService :
+    public virtual epics::pvAccess::RPCService
+{
+public:
+    POINTER_DEFINITIONS(ResumeService);
+
+    static ResumeService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return ResumeServicePtr(new ResumeService(pvRecord));
+    }
+    ~ResumeService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+private:
+    ResumeService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+class StopService :
+    public virtual epics::pvAccess::RPCService
+{
+public:
+    POINTER_DEFINITIONS(StopService);
+
+    static StopService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return StopServicePtr(new StopService(pvRecord));
+    }
+    ~StopService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+private:
+    StopService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+class RewindService :
+    public virtual epics::pvAccess::RPCService
+{
+public:
+    POINTER_DEFINITIONS(RewindService);
+
+    static RewindService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return RewindServicePtr(new RewindService(pvRecord));
+    }
+    ~RewindService() {};
+ 
+    epics::pvData::PVStructurePtr request(
+        epics::pvData::PVStructure::shared_pointer const & args
+    ) throw (epics::pvAccess::RPCRequestException);
+
+private:
+    int getRequestedSteps(epics::pvData::PVStructurePtr const & args);
+
+private:
+    RewindService(ExampleRPCPtr const & pvRecord)
+    : pvRecord(pvRecord)
+    {
+    }
+
+    ExampleRPCPtr pvRecord;
+};
+
+class ScanService :
+    public epics::pvAccess::RPCServiceAsync,
+    public std::tr1::enable_shared_from_this<ScanService>
+{
+public:
+    POINTER_DEFINITIONS(ScanService);
+
+    class Callback : public Device::Callback
+    {
+    public:
+        POINTER_DEFINITIONS(Callback);
+        static Callback::shared_pointer create(ScanServicePtr const & record);
+
+        virtual void setpointChanged(Point sp)
+        {
+            std::cout << "ScanService::Callback::setpointChanged" << std::endl;
+        }
+        virtual void readbackChanged(Point rb)
+        {
+            std::cout << "ScanService::Callback::readbackChanged" << std::endl;
+        }
+        virtual void stateChanged(Device::State state); /*
+        {
+            std::cout << "ScanService::Callback::stateChanged" << std::endl;
+        }*/
+        virtual void scanComplete(); /*
+        {
+            std::cout << "ScanService::Callback::scanComplete" << std::endl;
+        }*/
+
+    //private:
+        Callback(ScanServicePtr service)
+        : service(service)
+        {}
+
+        void handleError(const std::string & message);
+
+        ScanServicePtr service;
+        epics::pvAccess::RPCResponseCallback::shared_pointer callback;
+    };
+
+    static ScanService::shared_pointer create(ExampleRPCPtr const & pvRecord)
+    {
+        return ScanServicePtr(new ScanService(pvRecord));
     }
 
    void request(epics::pvData::PVStructurePtr const & args,
                 epics::pvAccess::RPCResponseCallback::shared_pointer const & callback);
 private:
-    ExampleRPCServiceAsync(ExampleRPCPtr const & pvRecord)
+    ScanService(ExampleRPCPtr const & pvRecord)
     : pvRecord(pvRecord)
     {
     }
@@ -88,8 +295,7 @@ private:
     ExampleRPCPtr pvRecord;
 };
 
-class ExampleRPC;
-typedef std::tr1::shared_ptr<ExampleRPC> ExampleRPCPtr;
+
 
 class epicsShareClass ExampleRPC :
     public epics::pvDatabase::PVRecord
@@ -103,20 +309,50 @@ public:
     virtual void process();
     virtual epics::pvAccess::Service::shared_pointer getService(
         epics::pvData::PVStructurePtr const & pvRequest);
-    void put(double x, double y);
 
-    bool takeControl();
-    void releaseControl();
+    class Callback : public Device::Callback
+    {
+    public:
+        POINTER_DEFINITIONS(Callback);
+        static Callback::shared_pointer create(ExampleRPCPtr const & record);
+
+       virtual void setpointChanged(Point sp);
+       virtual void readbackChanged(Point rb);
+       virtual void stateChanged(Device::State state);
+
+    private:
+        Callback(ExampleRPCPtr record)
+        : record(record)
+        {}
+        ExampleRPCPtr record;
+    };
+
+       virtual void setpointChanged(Point sp);
+       virtual void readbackChanged(Point rb);
+       virtual void stateChanged(Device::State state);
+
 private:
 
     ExampleRPC(std::string const & recordName,
         epics::pvData::PVStructurePtr const & pvStructure);
     void initPvt();
 
+    epics::pvData::PVDoublePtr      pvx;
+    epics::pvData::PVDoublePtr      pvy;
+    epics::pvData::PVDoublePtr      pvx_rb;
+    epics::pvData::PVDoublePtr      pvy_rb;
+
+    epics::pvData::PVIntPtr         pvStateIndex;
+    epics::pvData::PVStringArrayPtr pvStateChoices;
+
     epics::pvData::PVTimeStamp pvTimeStamp;
-    epics::pvData::TimeStamp timeStamp;
-    epics::pvData::Mutex taskMutex;
-    epics::pvAccess::Service::shared_pointer service;
+    epics::pvData::PVTimeStamp pvTimeStamp_sp;
+    epics::pvData::PVTimeStamp pvTimeStamp_rb;
+    epics::pvData::PVTimeStamp pvTimeStamp_st;
+
+    bool firstTime;
+public:
+    DevicePtr device;
 };
 
 

--- a/pvDatabaseRPC/src/pv/point.h
+++ b/pvDatabaseRPC/src/pv/point.h
@@ -1,0 +1,78 @@
+#ifndef EXAMPLERPC_POINT_H
+#define EXAMPLERPC_POINT_H
+
+
+#ifdef epicsExportSharedSymbols
+#   define pointExportSharedSymbols
+#   undef epicsExportSharedSymbols
+#endif
+
+#include <pv/pvDatabase.h>
+
+#include <pv/point.h>
+
+#include <epicsThread.h>
+
+#include <iostream>
+
+#ifdef pointExportSharedSymbols
+#   define epicsExportSharedSymbols
+#	undef pointExportSharedSymbols
+#endif
+
+#include <shareLib.h>
+
+namespace epics { namespace exampleCPP { namespace exampleRPC {
+
+epicsShareClass class Point
+{
+public:
+    Point()
+    : x(0), y(0)
+    {
+    }
+
+    Point(double x, double y)
+    : x(x), y(y)
+    {
+    }
+
+    Point(const Point & point)
+    : x(point.x), y(point.y)
+    {
+    }
+
+    Point operator=(const Point &rhs)
+    {
+        x = rhs.x;
+        y = rhs.y;
+        return *this;
+    }
+
+    double x;
+    double y;
+};
+
+
+inline bool operator==(const Point & lhs, const Point &rhs)
+{
+    return lhs.x == rhs.x && lhs.y == rhs.y;
+}
+
+inline bool operator!=(const Point & lhs, const Point &rhs)
+{
+    return !(lhs == rhs);
+}
+
+inline std::ostream & operator<< (std::ostream& os, const Point& point)
+{
+    os << "(" << point.x << "," << point.y << ")";
+    return os;
+}
+
+
+}}}
+
+#endif //EXAMPLERPC_POINT_H
+
+


### PR DESCRIPTION
More development of pvDatabaseRPC example. In place of a single, simple
"move" operation it now has a complex state machine and set of services:
Configure, run (non-blocking), pause, resume, scan (blocking),
rewind, stop and abort.

A state field has been added to the PV. Each of the 3 main fields (the
setpoint, readback and state) has a principal "value" field and time
stamp, in addition to a top-level "timeStamp" field. A client supporting
the operations has been provided.

It illustrates synchronous and asynchronous RPC services, selecting
services based on the supplied pvRequest and using EPICS V4 to talk to
an existing object which has no knowledge of EPICS and call its methods,
so creating distributed objects.

Documentation has been updated and help/usage for the operations has
been added to the client.