### PR TITLE
pvDatabaseRPC: Single update of record fields

### DIFF
--- a/pvDatabaseRPC/src/positionClient.cpp
+++ b/pvDatabaseRPC/src/positionClient.cpp
@@ -273,7 +273,6 @@ PVStructurePtr createConfigArgs(int argc, char *argv[])
     }
 
 	arguments->getSubField<PVStructureArray>("value")->replace(freeze(values));
-std::cout << "createConfigArgs\n" << arguments << std::endl;
     return arguments;
 }
 

--- a/pvDatabaseRPC/src/pv/device.h
+++ b/pvDatabaseRPC/src/pv/device.h
@@ -71,23 +71,19 @@ public:
    public:
        POINTER_DEFINITIONS(Callback);
 
-       virtual void setpointChanged(Point sp) {}
-       virtual void readbackChanged(Point rb){}
-       virtual void stateChanged(State state) {}
-       virtual void scanComplete() {}
+       virtual void update(int flags) = 0;
+
+       const static int SETPOINT_CHANGED  = 0x1;
+       const static int READBACK_CHANGED  = 0x2;
+       const static int STATE_CHANGED     = 0x4;
+       const static int SCAN_COMPLETE     = 0x8;
    };
 
     void registerCallback(Callback::shared_pointer const & callback);
 
     bool unregisterCallback(Callback::shared_pointer const & callback);
 
-    void setpointCallback(Point sp);
-
-    void readCallback(Point rb);
-
-    void stateCallback(State state);
-
-    void scanComplete();
+    void update();
 
     Point getPositionSetpoint();
 
@@ -118,7 +114,10 @@ private:
 
     void setStateImpl(State state);
 
+    void scanComplete();
+
     State state;
+    int flags;
 
     Point positionSP;
     Point positionRB;

--- a/pvDatabaseRPC/src/pv/exampleRPC.h
+++ b/pvDatabaseRPC/src/pv/exampleRPC.h
@@ -253,20 +253,13 @@ public:
 
         virtual void setpointChanged(Point sp)
         {
-            std::cout << "ScanService::Callback::setpointChanged" << std::endl;
         }
         virtual void readbackChanged(Point rb)
         {
-            std::cout << "ScanService::Callback::readbackChanged" << std::endl;
         }
-        virtual void stateChanged(Device::State state); /*
-        {
-            std::cout << "ScanService::Callback::stateChanged" << std::endl;
-        }*/
-        virtual void scanComplete(); /*
-        {
-            std::cout << "ScanService::Callback::scanComplete" << std::endl;
-        }*/
+        virtual void stateChanged(Device::State state);
+
+        virtual void scanComplete();
 
     //private:
         Callback(ScanServicePtr service)
@@ -316,9 +309,10 @@ public:
         POINTER_DEFINITIONS(Callback);
         static Callback::shared_pointer create(ExampleRPCPtr const & record);
 
-       virtual void setpointChanged(Point sp);
-       virtual void readbackChanged(Point rb);
-       virtual void stateChanged(Device::State state);
+        virtual void setpointChanged(Point sp);
+        virtual void readbackChanged(Point rb);
+        virtual void stateChanged(Device::State state);
+        virtual void update(int flags) {}
 
     private:
         Callback(ExampleRPCPtr record)

--- a/pvDatabaseRPC/src/pv/exampleRPC.h
+++ b/pvDatabaseRPC/src/pv/exampleRPC.h
@@ -2,11 +2,11 @@
  * Copyright information and license terms for this software can be
  * found in the file LICENSE that is included with the distribution
  */
-
 /**
  * @author dgh
  * @date 2015.12.08
  */
+
 #ifndef EXAMPLERPC_H
 #define EXAMPLERPC_H
 
@@ -57,10 +57,9 @@ class ScanService;
 typedef std::tr1::shared_ptr<ScanService> ScanServicePtr;
 
 
+
 class ExampleRPC;
 typedef std::tr1::shared_ptr<ExampleRPC> ExampleRPCPtr;
-
-
 
 
 
@@ -245,31 +244,22 @@ class ScanService :
 public:
     POINTER_DEFINITIONS(ScanService);
 
+    virtual void update(int flags);
+
     class Callback : public Device::Callback
     {
     public:
         POINTER_DEFINITIONS(Callback);
         static Callback::shared_pointer create(ScanServicePtr const & record);
 
-        virtual void setpointChanged(Point sp)
-        {
-        }
-        virtual void readbackChanged(Point rb)
-        {
-        }
-        virtual void stateChanged(Device::State state);
+        virtual void update(int flags);
 
-        virtual void scanComplete();
-
-    //private:
+    private:
         Callback(ScanServicePtr service)
         : service(service)
         {}
 
-        void handleError(const std::string & message);
-
         ScanServicePtr service;
-        epics::pvAccess::RPCResponseCallback::shared_pointer callback;
     };
 
     static ScanService::shared_pointer create(ExampleRPCPtr const & pvRecord)
@@ -284,6 +274,16 @@ private:
     : pvRecord(pvRecord)
     {
     }
+
+    virtual void stateChanged(Device::State state);
+
+    virtual void scanComplete();
+
+    void handleError(const std::string & message);
+
+    epics::pvAccess::RPCResponseCallback::shared_pointer rpcCallback;
+
+    Callback::shared_pointer deviceCallback;
 
     ExampleRPCPtr pvRecord;
 };
@@ -309,10 +309,7 @@ public:
         POINTER_DEFINITIONS(Callback);
         static Callback::shared_pointer create(ExampleRPCPtr const & record);
 
-        virtual void setpointChanged(Point sp);
-        virtual void readbackChanged(Point rb);
-        virtual void stateChanged(Device::State state);
-        virtual void update(int flags) {}
+        virtual void update(int flags);
 
     private:
         Callback(ExampleRPCPtr record)
@@ -321,9 +318,9 @@ public:
         ExampleRPCPtr record;
     };
 
-       virtual void setpointChanged(Point sp);
-       virtual void readbackChanged(Point rb);
-       virtual void stateChanged(Device::State state);
+    virtual void update(int flags);
+
+    DevicePtr getDevice() { return device; }
 
 private:
 
@@ -345,7 +342,7 @@ private:
     epics::pvData::PVTimeStamp pvTimeStamp_st;
 
     bool firstTime;
-public:
+
     DevicePtr device;
 };
 

--- a/pvDatabaseRPC/src/pv/point.h
+++ b/pvDatabaseRPC/src/pv/point.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+/**
+ * @author Dave Hickin
+ *
+ */
+
 #ifndef EXAMPLERPC_POINT_H
 #define EXAMPLERPC_POINT_H
 


### PR DESCRIPTION
Update fields of record as single update rather than in several goes.
Prevents overruns and avoids issues with missed updates.