### PR TITLE
add simpleBusyRecord

### DIFF
--- a/arrayPerformance/src/Makefile
+++ b/arrayPerformance/src/Makefile
@@ -46,6 +46,8 @@ vectorPerformanceMain_SRCS += vectorPerformanceMain.cpp
 vectorPerformanceMain_LIBS +=  pvData Com
 
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 
 include $(TOP)/configure/RULES
 

--- a/database/ioc/Db/Makefile
+++ b/database/ioc/Db/Makefile
@@ -19,6 +19,7 @@ DB += dbEnum.db
 DB += dbCounter.db
 DB += dbDouble.db
 DB += test.db
+DB += dbSimpleBusy.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/database/ioc/Db/dbSimpleBusy.db
+++ b/database/ioc/Db/dbSimpleBusy.db
@@ -1,0 +1,3 @@
+record(simpleBusy, "${name}")
+{
+}

--- a/database/ioc/Db/test.db
+++ b/database/ioc/Db/test.db
@@ -96,6 +96,22 @@ record(mbbo,"DBRmbbo00") {
     field(TTVL,"0xd")
     field(FTVL,"0xe")
     field(FFVL,"0xf")
+    field(ZRST,"0x0")
+    field(ONST,"0x1")
+    field(TWST,"0x2")
+    field(THST,"0x3")
+    field(FRST,"0x4")
+    field(FVST,"0x5")
+    field(SXST,"0x6")
+    field(SVST,"0x7")
+    field(EIST,"0x8")
+    field(NIST,"0x9")
+    field(TEST,"0xa")
+    field(ELST,"0xb")
+    field(TVST,"0xc")
+    field(TTST,"0xd")
+    field(FTST,"0xe")
+    field(FFVL,"0xf")
 }
 
 record(mbbi,"DBRmbbiwierd") {
@@ -115,7 +131,7 @@ record(bo,"DBRbo01") {
     field(ONAM,"one")
 }
 
-record(mbbo,"DBRmbbo02") {
+record(mbbo,"DBRmbbo01") {
     field(VAL,"1")
     field(ZRST,"zero")
     field(ONST,"one")

--- a/database/ioc/src/Makefile
+++ b/database/ioc/src/Makefile
@@ -34,8 +34,8 @@ exampleDatabase_LIBS += exampleDatabase
 exampleDatabase_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 exampleDatabase_LIBS += example
 exampleDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)
+exampleDatabase_SYS_LIBS_WIN32 += ws2_32
 
-PROD_SYS_LIBS_WIN32 += ws2_32
 
 #===========================
 

--- a/database/ioc/src/Makefile
+++ b/database/ioc/src/Makefile
@@ -14,6 +14,7 @@ DBD += exampleDatabase.dbd
 DBDINC += simpleBusyRecord
 
 example_SRCS += simpleBusyRecord.c
+example_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #=============================
 # build an ioc application
@@ -34,7 +35,8 @@ exampleDatabase_LIBS += exampleDatabase
 exampleDatabase_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 exampleDatabase_LIBS += example
 exampleDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)
-exampleDatabase_SYS_LIBS_WIN32 += ws2_32
+
+PROD_SYS_LIBS_WIN32 += ws2_32
 
 
 #===========================

--- a/database/ioc/src/Makefile
+++ b/database/ioc/src/Makefile
@@ -35,6 +35,8 @@ exampleDatabase_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvDat
 exampleDatabase_LIBS += example
 exampleDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/database/ioc/src/Makefile
+++ b/database/ioc/src/Makefile
@@ -8,8 +8,12 @@ include $(TOP)/configure/CONFIG
 #==================================================
 # Build an IOC support library
 #
+LIBRARY_IOC += example
 
 DBD += exampleDatabase.dbd
+DBDINC += simpleBusyRecord
+
+example_SRCS += simpleBusyRecord.c
 
 #=============================
 # build an ioc application
@@ -28,6 +32,7 @@ exampleDatabase_OBJS_vxWorks += $(EPICS_BASE_BIN)/vxComLibrary
 
 exampleDatabase_LIBS += exampleDatabase
 exampleDatabase_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
+exampleDatabase_LIBS += example
 exampleDatabase_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 #===========================

--- a/database/ioc/src/exampleDatabaseInclude.dbd
+++ b/database/ioc/src/exampleDatabaseInclude.dbd
@@ -1,4 +1,5 @@
 include "base.dbd"
+include "simpleBusyRecord.dbd"
 include "PVAServerRegister.dbd"
 include "registerChannelProviderLocal.dbd"
 include "qsrv.dbd"

--- a/database/ioc/src/simpleBusyRecord.c
+++ b/database/ioc/src/simpleBusyRecord.c
@@ -1,0 +1,113 @@
+/*************************************************************************\
+* Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution. 
+\*************************************************************************/
+
+/* Revision-Id: anj@aps.anl.gov-20131120222110-3o0wgh76u652ad4e */
+
+/* recLongin.c - Record Support Routines for Longin records */
+/*
+ *      Author: 	Janet Anderson
+ *      Date:   	9/23/91
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dbDefs.h"
+#include "epicsPrint.h"
+#include "alarm.h"
+#include "dbAccess.h"
+#include "dbEvent.h"
+#include "dbFldTypes.h"
+#include "devSup.h"
+#include "errMdef.h"
+#include "recSup.h"
+#include "recGbl.h"
+#include "menuYesNo.h"
+
+#define GEN_SIZE_OFFSET
+#include "simpleBusyRecord.h"
+#undef  GEN_SIZE_OFFSET
+#include "epicsExport.h"
+
+/* Create RSET - Record Support Entry Table*/
+#define report NULL
+#define initialize NULL
+static long init_record(simpleBusyRecord *, int);
+static long process(simpleBusyRecord *);
+static long special(struct dbAddr *paddr, int after);
+#define get_value NULL
+#define cvt_dbaddr NULL
+#define get_array_info NULL
+#define put_array_info NULL
+#define get_units NULL
+#define get_precision NULL
+#define get_enum_str NULL
+#define get_enum_strs NULL
+#define put_enum_str NULL
+#define get_graphic_double NULL
+#define get_control_double NULL
+#define get_alarm_double NULL
+
+
+rset simpleBusyRSET={
+	RSETNUMBER,
+	report,
+	initialize,
+	init_record,
+	process,
+	special,
+	get_value,
+	cvt_dbaddr,
+	get_array_info,
+	put_array_info,
+	get_units,
+	get_precision,
+	get_enum_str,
+	get_enum_strs,
+	put_enum_str,
+	get_graphic_double,
+	get_control_double,
+	get_alarm_double
+};
+epicsExportAddress(rset,simpleBusyRSET);
+
+
+static long init_record(simpleBusyRecord *prec, int pass)
+{
+    prec->val = 0;
+    prec->udf = FALSE;
+    recGblResetAlarms(prec);
+    return(0);
+}
+
+static long process(simpleBusyRecord *prec)
+{
+    recGblGetTimeStamp(prec);
+    unsigned short monitor_mask = DBE_VALUE;
+    db_post_events(prec, &prec->val, monitor_mask);
+    if(prec->val!=0) {
+        prec->pact = TRUE;
+        return 0;
+    }
+    recGblFwdLink(prec);
+    prec->pact=FALSE;
+    return 0;
+}
+
+static long special(struct dbAddr *paddr, int after)
+{
+    if(after==0) return 0;
+    struct dbCommon *prec = paddr->precord;
+    if(prec->pact==FALSE) return 0;
+    prec->rset->process(prec);
+    return 0;
+}

--- a/database/ioc/src/simpleBusyRecord.dbd
+++ b/database/ioc/src/simpleBusyRecord.dbd
@@ -1,0 +1,19 @@
+#*************************************************************************
+# Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+#     National Laboratory.
+# Copyright (c) 2002 The Regents of the University of California, as
+#     Operator of Los Alamos National Laboratory.
+# EPICS BASE Versions 3.13.7
+# and higher are distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution. 
+#*************************************************************************
+recordtype(simpleBusy) {
+	include "dbCommon.dbd" 
+	field(VAL,DBF_LONG) {
+		prompt("Current value")
+                special(SPC_MOD)
+                promptgroup(GUI_INPUTS)
+		asl(ASL0)
+		pp(TRUE)
+	}
+}

--- a/database/iocBoot/exampleDatabase/st.cmd
+++ b/database/iocBoot/exampleDatabase/st.cmd
@@ -10,8 +10,10 @@ exampleDatabase_registerRecordDeviceDriver(pdbbase)
 dbLoadRecords("db/dbStringArray.db","name=DBRstringArray01")
 dbLoadRecords("db/dbEnum.db","name=DBRenum01")
 dbLoadRecords("db/dbCounter.db","name=DBRcounter01")
+dbLoadRecords("db/dbSimpleBusy.db","name=DBRbusy")
 dbLoadRecords("db/dbArray.db","name=DBRdoubleArray,type=DOUBLE")
 dbLoadRecords("db/test.db")
+
 
 
 cd ${TOP}/iocBoot/${IOC}

--- a/database/src/Makefile
+++ b/database/src/Makefile
@@ -33,5 +33,8 @@ exampleHelloRPCClient_SRCS += exampleHelloRPCClient.cpp
 exampleHelloRPCClient_LIBS += pvaClient pvAccess pvAccessCA nt pvData ca Com
 
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
+
 include $(TOP)/configure/RULES
 

--- a/database/src/exampleSoftRecord.cpp
+++ b/database/src/exampleSoftRecord.cpp
@@ -9,10 +9,11 @@
  */
 
 #include <pv/standardField.h>
+#include <pv/ntscalar.h>
 
 #define epicsExportSharedSymbols
 #include <pv/exampleSoftRecord.h>
-#include <pv/ntscalar.h>
+
 
 using namespace epics::pvData;
 using namespace epics::pvDatabase;

--- a/documentation/database.html
+++ b/documentation/database.html
@@ -26,7 +26,7 @@
 
 <div class="head">
 <h1>EPICS exampleCPP/database</h1>
-<h2 class="nocount">2017.10.14</h2>
+<h2 class="nocount">2017.10.21</h2>
 
 <h2 class="nocount">Abstract</h2>
 <p>database provides an IOC with a combination of V3 DBRecords, PVRecords, and also starts qsrv.
@@ -167,6 +167,7 @@ DBRmbbo02
 DBRbo00
 DBRbo01
 DBRmbbiwierd
+DBRbusy
 </pre>
 <h2>database/src/pv</h2>
 <p>This directory has the following files:</p>
@@ -430,6 +431,19 @@ They are used when the example database is started as part of a V3 IOC.</p>
         <dl>
            <dt>include "base.dbd"</dt>
               <dd>This is from iocCore</dd>
+           <dt>include "simpleBusyRecord.dbd"</dt>
+              <dd>
+                 <p>
+                 This is a DBRecord that is a simplified version of the synapps busy record.
+                 It is a record that sets pact=True when a 1 is written to it and to False when
+                 a 0 is written to it.
+                 </p>
+                 <p>
+                 It can be used to test the ca provider from both pvAccessCPP and pvAccessJava.
+                 It can also be used to test qsrv from pva2pva.
+                 Each of these implements put with and without callback.  
+                 </p>
+              </dd>
            <dt>include "PVAServerRegister.dbd"</dt>
               <dd>This is to create the iocsh commmand <b>startPVAServer</b></dd>
            <dt>include "registerChannelProviderLocal.dbd"</dt>

--- a/exampleClient/src/Makefile
+++ b/exampleClient/src/Makefile
@@ -62,6 +62,9 @@ putUnion_SRCS += putUnion.cpp
 putUnion_LIBS += pvaClient pvAccess pvAccessCA nt pvData ca Com
 
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/exampleClient/src/putNoBlock.cpp
+++ b/exampleClient/src/putNoBlock.cpp
@@ -127,7 +127,6 @@ public:
         ConvertPtr convert = getConvert();
         if(pvScalar) {
             convert->fromString(pvScalar,value);
-            pvaClientPut->put();
         } else {
             vector<string> values;
             size_t pos = 0;

--- a/exampleLink/ioc/src/Makefile
+++ b/exampleLink/ioc/src/Makefile
@@ -31,6 +31,8 @@ exampleLink_LIBS += exampleLink
 exampleLink_LIBS += pvDatabase pvaClient qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 exampleLink_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/exampleLink/src/Makefile
+++ b/exampleLink/src/Makefile
@@ -34,6 +34,8 @@ exampleLinkMain_SRCS += exampleLinkMain.cpp
 exampleLinkMain_LIBS += exampleLink
 exampleLinkMain_LIBS += pvDatabase pvaClient pvAccess pvAccessCA nt pvData ca Com
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 
 include $(TOP)/configure/RULES
 

--- a/helloPutGet/ioc/src/Makefile
+++ b/helloPutGet/ioc/src/Makefile
@@ -30,6 +30,8 @@ helloPutGet_LIBS += helloPutGet
 helloPutGet_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 helloPutGet_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/helloPutGet/src/Makefile
+++ b/helloPutGet/src/Makefile
@@ -32,6 +32,8 @@ helloNoWaitPutGetClient_LIBS += pvaClient
 helloNoWaitPutGetClient_LIBS += pvAccess pvAccessCA pvData ca Com
 
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 
 include $(TOP)/configure/RULES
 

--- a/powerSupply/ioc/src/Makefile
+++ b/powerSupply/ioc/src/Makefile
@@ -30,6 +30,8 @@ powerSupply_LIBS += powerSupply
 powerSupply_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 powerSupply_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/powerSupply/src/Makefile
+++ b/powerSupply/src/Makefile
@@ -33,5 +33,8 @@ powerSupplyMonitor_SRCS += powerSupplyMonitor.cpp
 powerSupplyMonitor_LIBS += pvaClient pvAccess pvAccessCA pvData ca Com
 
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
+
 include $(TOP)/configure/RULES
 

--- a/pvDatabaseRPC/ioc/src/Makefile
+++ b/pvDatabaseRPC/ioc/src/Makefile
@@ -30,6 +30,8 @@ exampleRPC_LIBS += exampleRPC
 exampleRPC_LIBS += pvDatabase qsrv pvAccessIOC pvAccess pvAccessCA nt pvData
 exampleRPC_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 #===========================
 
 include $(TOP)/configure/RULES

--- a/pvDatabaseRPC/src/Makefile
+++ b/pvDatabaseRPC/src/Makefile
@@ -28,6 +28,8 @@ PROD_HOST += control
 control_SRCS += positionClient.cpp
 control_LIBS += pvAccess pvAccessCA pvData Com
 
+PROD_SYS_LIBS_WIN32 += ws2_32
+
 
 include $(TOP)/configure/RULES
 


### PR DESCRIPTION
simpleBusyRecord is a drastically simplified version of the synapps  busyRecord.
It was added so that ca provider (In particular channelPut)  from both pvAccessCPP and pvAccessJava could be tested, without requiring anything from synapps.

Formally the ca providers  only supported put with callback.
The new versions now  support put both with and without callback.
The default, just like caput and qsrv, is put without callback.
To ask for put with callback the client must specify
record[block=true]
in pvRequest when creating the channelPut.