### PR TITLE
Example RELEASE.local files are incorrect

### DIFF
--- a/ExampleRELEASE.local
+++ b/ExampleRELEASE.local
@@ -5,12 +5,13 @@
 
 EPICS7_DIR=/home/install/epics/base-7.0.4
 
-PVDATABASE=${EPICS7_DIR}/modules/database
-PVACLIENT=${EPICS7_DIR}/modules/pvaClient
-PVA2PVA=${EPICS7_DIR}/modules/pva2pva
-PVACCESS=${EPICS7_DIR}/modules/pvAccess
-NORMATIVETYPES=${EPICS7_DIR}modules/normativeTypes
-PVDATA=${EPICS7_DIR}modules/pvData
-EPICS_BASE=${EPICS7_DIR}
+# Do not change these paths (or the order)
+EPICS_BASE=$(EPICS7_DIR)
+PVDATABASE=$(EPICS7_DIR)/modules/database
+PVACLIENT=$(EPICS7_DIR)/modules/pvaClient
+PVA2PVA=$(EPICS7_DIR)/modules/pva2pva
+PVACCESS=$(EPICS7_DIR)/modules/pvAccess
+NORMATIVETYPES=$(EPICS7_DIR)/modules/normativeTypes
+PVDATA=$(EPICS7_DIR)/modules/pvData
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 

--- a/MasterRELEASE.local
+++ b/MasterRELEASE.local
@@ -3,13 +3,14 @@
 # Change the first line and also EPICS_BASE and also possibly EPICS_BASE
 # type make at top level
 EPICS7_DIR=/home/epics7
-PVDATABASE=${EPICS7_DIR}/modules/pvDatabaseCPP
-PVACLIENT=${EPICS7_DIR}/modules/pvaClientCPP
-PVA2PVA=${EPICS7_DIR}/modules/pva2pva
-PVACCESS=${EPICS7_DIR}/modules/pvAccessCPP
-NORMATIVETYPES=${EPICS7_DIR}/modules/normativeTypesCPP
-PVDATA=${EPICS7_DIR}/modules/pvDataCPP
-PVCOMMON=${EPICS7_DIR}/modules/pvCommonCPP
-EPICS_BASE=${EPICS7_DIR}/epics-base
+
+EPICS_BASE=$(EPICS7_DIR)/epics-base
+PVDATABASE=$(EPICS7_DIR)/modules/pvDatabaseCPP
+PVACLIENT=$(EPICS7_DIR)/modules/pvaClientCPP
+PVA2PVA=$(EPICS7_DIR)/modules/pva2pva
+PVACCESS=$(EPICS7_DIR)/modules/pvAccessCPP
+NORMATIVETYPES=$(EPICS7_DIR)/modules/normativeTypesCPP
+PVDATA=$(EPICS7_DIR)/modules/pvDataCPP
+PVCOMMON=$(EPICS7_DIR)/modules/pvCommonCPP
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 


### PR DESCRIPTION
Parenthesis needed instead of curly braces. This hopefully corrects the issue.

I was having an issue when trying to use this example in combination with PVXS also (see [here](https://github.com/mdavidsaver/pvxs/issues/15) for details).

An open question on this - why are the other variables needed (below)?
It seems to build fine for me without them. Don't we just need `EPICS_BASE`?
```bash
PVDATABASE=$(EPICS7_DIR)/modules/database
PVACLIENT=$(EPICS7_DIR)/modules/pvaClient
PVA2PVA=$(EPICS7_DIR)/modules/pva2pva
PVACCESS=$(EPICS7_DIR)/modules/pvAccess
NORMATIVETYPES=$(EPICS7_DIR)/modules/normativeTypes
PVDATA=$(EPICS7_DIR)/modules/pvData
TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
```